### PR TITLE
feat: make tag-version.yml reusable

### DIFF
--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -2,6 +2,7 @@ name: Tag Version
 
 on:
   workflow_dispatch:
+  workflow_call:
   push:
     branches:
       - main

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.6.1
+VERSION=0.6.2
 
 # Include our own shared targets
 include make/version.mk


### PR DESCRIPTION
## Summary
- Add `workflow_call` trigger to `tag-version.yml` so other repos can use it as a reusable workflow
- Bump version to 0.6.2

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)