### PR TITLE
fix: replace --network=host with appPort in devcontainer example

### DIFF
--- a/devcontainer/README.md
+++ b/devcontainer/README.md
@@ -79,9 +79,9 @@ Each project maintains its own `conda-packages.txt` with project-specific depend
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "initializeCommand": "bash .devcontainer/init-host.sh",
+  "appPort": [8000],
   "runArgs": [
-    "--name=dc-my-project",
-    "--network=host"
+    "--name=dc-my-project"
   ],
   "mounts": [
     "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached",


### PR DESCRIPTION
## Summary
- Replaces `--network=host` with `appPort: [8000]` in the example devcontainer.json
- `--network=host` is a no-op on macOS Docker Desktop (container runs in a Linux VM)
- `appPort` uses Docker's `-p` flag, which works on both macOS and Linux with the devcontainers CLI

Closes #28

## Test plan
- [ ] Verify new projects scaffolded from devtemplate get working port mapping on macOS
- [ ] Verify port mapping still works on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)