### PR TITLE
fix: remove appPort from base template example

### DIFF
--- a/devcontainer/README.md
+++ b/devcontainer/README.md
@@ -79,7 +79,6 @@ Each project maintains its own `conda-packages.txt` with project-specific depend
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "initializeCommand": "bash .devcontainer/init-host.sh",
-  "appPort": [8000],
   "runArgs": [
     "--name=dc-my-project"
   ],


### PR DESCRIPTION
## Summary
- Removes `appPort: [8000]` from the example devcontainer.json in the README
- Not all projects expose a server port — only projects with a web server (like gam-viz) need `appPort`
- Projects that need it should add `appPort` to their own devcontainer.json

Follow-up to #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)