### PR TITLE
feat: add install-requirements input to reusable CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ on:
       run-lint:
         type: boolean
         default: true
+      install-requirements:
+        type: boolean
+        default: true
 
 jobs:
   ci:
@@ -34,10 +37,12 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
 
-      - name: Install dependencies
-        run: |
-          pip install -r ${{ inputs.requirements-file }}
-          pip install ruff pytest pytest-cov
+      - name: Install project requirements
+        if: inputs.install-requirements
+        run: pip install -r ${{ inputs.requirements-file }}
+
+      - name: Install dev tools
+        run: pip install ruff pytest pytest-cov
 
       - name: Lint
         if: inputs.run-lint


### PR DESCRIPTION
## Summary
- Adds `install-requirements` boolean input (default `true`) to `.github/workflows/ci.yml`
- Gates the `pip install -r requirements-prod.txt` step on the new input
- Splits the install step into "project requirements" (conditional) and "dev tools" (always) for clarity
- Existing callers are unchanged — they get the same behavior as before

Closes #34. Unblocks devtemplate PR #19 CI.

## Test plan
- [x] Existing callers: default `install-requirements: true` preserves current behavior
- [ ] devtemplate caller PR (next) sets `install-requirements: false, run-tests: false` and goes green