### PR TITLE
feat: install claude-min shim in setup-claude.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.7.5
+VERSION=0.7.6
 
 # Include our own shared targets
 include make/version.mk

--- a/devcontainer/setup-claude.sh
+++ b/devcontainer/setup-claude.sh
@@ -14,3 +14,41 @@ if ! command -v claude >/dev/null 2>&1; then
 else
   echo "    Claude Code CLI already installed"
 fi
+
+# Install the claude-min shim that proxies to the prod-min wrapper over SSH.
+# The corresponding server-side scripts and one-time setup live in
+# brianholland/home-site:claude-access/.  The private key is expected at
+# ~/.claude/credentials/claude-min-readonly (the host ~/.claude is bind-
+# mounted into every devcontainer per devtemplate's devcontainer.json).
+echo "==> Installing claude-min shim..."
+sudo tee /usr/local/bin/claude-min >/dev/null <<'CLAUDE_MIN_EOF'
+#!/usr/bin/env bash
+# claude-min — devcontainer-side wrapper that ssh's the original command
+# to the constrained `claude` account on min (or another host via
+# CLAUDE_MIN_HOST). The remote authorized_keys forces invocation of the
+# server-side claude-min wrapper, which validates against an allowlist.
+set -euo pipefail
+
+KEY="${HOME}/.claude/credentials/claude-min-readonly"
+HOST="${CLAUDE_MIN_HOST:-min}"
+
+if [[ ! -r "$KEY" ]]; then
+  echo "claude-min: missing key at $KEY" >&2
+  echo "claude-min: run the one-time setup in home-site/claude-access/INSTALL.md" >&2
+  exit 2
+fi
+if [[ "$#" -eq 0 ]]; then
+  echo "claude-min: usage: claude-min <verb> [args...]" >&2
+  echo "claude-min: e.g. claude-min docker-logs hog --tail 200" >&2
+  exit 2
+fi
+
+exec ssh \
+  -i "$KEY" \
+  -o IdentitiesOnly=yes \
+  -o StrictHostKeyChecking=accept-new \
+  -o BatchMode=yes \
+  "claude@${HOST}" "$@"
+CLAUDE_MIN_EOF
+sudo chmod 0755 /usr/local/bin/claude-min
+echo "    claude-min shim installed at /usr/local/bin/claude-min"


### PR DESCRIPTION
## Summary

Adds a postCreate-time install of \`/usr/local/bin/claude-min\` in every devcontainer that sources \`devcontainer/setup-claude.sh\`. The shim ssh's the original command to \`claude@\${CLAUDE_MIN_HOST:-min}\`; on the server side, a constrained \`authorized_keys\` forces the request through a server-side wrapper that validates against an allowlist.

## What lands here

- \`devcontainer/setup-claude.sh\` — adds a heredoc that writes \`/usr/local/bin/claude-min\` and chmods it 0755. Inlined to keep this PR self-contained (no cross-repo dependency on home-site).
- \`Makefile\` — VERSION 0.7.5 → 0.7.6.

## What the shim does

\`\`\`
claude-min docker-logs hog --tail 200
\`\`\`

becomes

\`\`\`
ssh -i ~/.claude/credentials/claude-min-readonly \\
    -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o BatchMode=yes \\
    claude@min docker-logs hog --tail 200
\`\`\`

Missing key → exits 2 with a usage hint; nothing on the server side is touched.

\`CLAUDE_MIN_HOST\` defaults to \`min\` but is overridable so the same shim will target the staging stack once brianholland/home-site#64 lands.

## What this PR does NOT do

- Generate the keypair, install it on the prod host, or create the \`claude\` user there. Those one-time setup steps are documented in \`brianholland/home-site\` PR #68 (\`claude-access/INSTALL.md\`).
- Provide the server-side wrapper. Same other PR.
- Take effect in existing devcontainers automatically — they need a rebuild after this lands.

## Bumps required after merge

Each repo that uses dev-common as a submodule needs \`make common-update\` + a version bump to pick up the shim install. Standard cascade pattern; no urgency, propagates as repos get updated.

## Related

- brianholland/home-site#65 (the umbrella issue and the server-side scripts)
- brianholland/home-site#64 (staging — the \`CLAUDE_MIN_HOST\` indirection is for this)