### PR TITLE
rename: claude-min shim → claude-prod (host-portable)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.7.6
+VERSION=0.7.7
 
 # Include our own shared targets
 include make/version.mk

--- a/devcontainer/setup-claude.sh
+++ b/devcontainer/setup-claude.sh
@@ -15,31 +15,31 @@ else
   echo "    Claude Code CLI already installed"
 fi
 
-# Install the claude-min shim that proxies to the prod-min wrapper over SSH.
+# Install the claude-prod shim that proxies to the prod wrapper over SSH.
 # The corresponding server-side scripts and one-time setup live in
 # brianholland/home-site:claude-access/.  The private key is expected at
-# ~/.claude/credentials/claude-min-readonly (the host ~/.claude is bind-
+# ~/.claude/credentials/claude-prod-readonly (the host ~/.claude is bind-
 # mounted into every devcontainer per devtemplate's devcontainer.json).
-echo "==> Installing claude-min shim..."
-sudo tee /usr/local/bin/claude-min >/dev/null <<'CLAUDE_MIN_EOF'
+echo "==> Installing claude-prod shim..."
+sudo tee /usr/local/bin/claude-prod >/dev/null <<'CLAUDE_PROD_EOF'
 #!/usr/bin/env bash
-# claude-min — devcontainer-side wrapper that ssh's the original command
-# to the constrained `claude` account on min (or another host via
-# CLAUDE_MIN_HOST). The remote authorized_keys forces invocation of the
-# server-side claude-min wrapper, which validates against an allowlist.
+# claude-prod — devcontainer-side wrapper that ssh's the original command
+# to the constrained `claude` account on prod (or another host via
+# CLAUDE_PROD_HOST). The remote authorized_keys forces invocation of the
+# server-side claude-prod wrapper, which validates against an allowlist.
 set -euo pipefail
 
-KEY="${HOME}/.claude/credentials/claude-min-readonly"
-HOST="${CLAUDE_MIN_HOST:-min}"
+KEY="${HOME}/.claude/credentials/claude-prod-readonly"
+HOST="${CLAUDE_PROD_HOST:-prod}"
 
 if [[ ! -r "$KEY" ]]; then
-  echo "claude-min: missing key at $KEY" >&2
-  echo "claude-min: run the one-time setup in home-site/claude-access/INSTALL.md" >&2
+  echo "claude-prod: missing key at $KEY" >&2
+  echo "claude-prod: run the one-time setup in home-site/claude-access/INSTALL.md" >&2
   exit 2
 fi
 if [[ "$#" -eq 0 ]]; then
-  echo "claude-min: usage: claude-min <verb> [args...]" >&2
-  echo "claude-min: e.g. claude-min docker-logs hog --tail 200" >&2
+  echo "claude-prod: usage: claude-prod <verb> [args...]" >&2
+  echo "claude-prod: e.g. claude-prod docker-logs hog --tail 200" >&2
   exit 2
 fi
 
@@ -49,6 +49,6 @@ exec ssh \
   -o StrictHostKeyChecking=accept-new \
   -o BatchMode=yes \
   "claude@${HOST}" "$@"
-CLAUDE_MIN_EOF
-sudo chmod 0755 /usr/local/bin/claude-min
-echo "    claude-min shim installed at /usr/local/bin/claude-min"
+CLAUDE_PROD_EOF
+sudo chmod 0755 /usr/local/bin/claude-prod
+echo "    claude-prod shim installed at /usr/local/bin/claude-prod"


### PR DESCRIPTION
## Summary
- Rename the devcontainer-side shim from \`claude-min\` to \`claude-prod\`. Decouples the abstraction from any particular host (\`min\`, future cloud, etc.).
- Default target host: \`prod\` (was \`min\`). Env override: \`CLAUDE_PROD_HOST\` (was \`CLAUDE_MIN_HOST\`).
- Private-key path: \`~/.claude/credentials/claude-prod-readonly\` (was \`claude-min-readonly\`).
- VERSION bumped 0.7.6 → 0.7.7.

Pairs with the server-side rename in brianholland/home-site#65 / PR home-site#69. Devcontainers pick up the new shim name on next rebuild.

## Test plan
- [ ] CI green
- [ ] After merge: home-site bumps dev-common pointer; devcontainer rebuild installs \`/usr/local/bin/claude-prod\`
- [ ] \`CLAUDE_PROD_HOST=<ip> claude-prod docker-ps\` succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)