### PR TITLE
feat: add claude-dev shim install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.7.7
+VERSION=0.7.8
 
 # Include our own shared targets
 include make/version.mk

--- a/devcontainer/setup-claude.sh
+++ b/devcontainer/setup-claude.sh
@@ -52,3 +52,41 @@ exec ssh \
 CLAUDE_PROD_EOF
 sudo chmod 0755 /usr/local/bin/claude-prod
 echo "    claude-prod shim installed at /usr/local/bin/claude-prod"
+
+# Install the claude-dev shim that proxies to the dev wrapper over SSH.
+# Parallel to claude-prod above; targets twix (the dev host) by default.
+# Server-side scripts and one-time setup live in
+# brianholland/home-site:claude-access/INSTALL-dev.md.
+echo "==> Installing claude-dev shim..."
+sudo tee /usr/local/bin/claude-dev >/dev/null <<'CLAUDE_DEV_EOF'
+#!/usr/bin/env bash
+# claude-dev - devcontainer-side wrapper that ssh's the original command
+# to the constrained `claude` account on the dev host (twix by default,
+# or another host via CLAUDE_DEV_HOST). The remote authorized_keys forces
+# invocation of the server-side claude-dev wrapper, which validates
+# against an allowlist.
+set -euo pipefail
+
+KEY="${HOME}/.claude/credentials/claude-dev-readonly"
+HOST="${CLAUDE_DEV_HOST:-twix}"
+
+if [[ ! -r "$KEY" ]]; then
+  echo "claude-dev: missing key at $KEY" >&2
+  echo "claude-dev: run the one-time setup in home-site/claude-access/INSTALL-dev.md" >&2
+  exit 2
+fi
+if [[ "$#" -eq 0 ]]; then
+  echo "claude-dev: usage: claude-dev <verb> [args...]" >&2
+  echo "claude-dev: e.g. claude-dev docker-logs hog --tail 200" >&2
+  exit 2
+fi
+
+exec ssh \
+  -i "$KEY" \
+  -o IdentitiesOnly=yes \
+  -o StrictHostKeyChecking=accept-new \
+  -o BatchMode=yes \
+  "claude@${HOST}" "$@"
+CLAUDE_DEV_EOF
+sudo chmod 0755 /usr/local/bin/claude-dev
+echo "    claude-dev shim installed at /usr/local/bin/claude-dev"


### PR DESCRIPTION
Closes #41. Mirrors the existing claude-prod shim install in setup-claude.sh. After merge, consumers pick up via make common-update; shim becomes active on next devcontainer rebuild.