### PR TITLE
feat: set LANG=C.UTF-8 in devcontainer bashrc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.7.10
+VERSION=0.7.11
 
 # Include our own shared targets
 include make/version.mk

--- a/devcontainer/setup-base.sh
+++ b/devcontainer/setup-base.sh
@@ -63,6 +63,13 @@ if ! grep -q "$MARKER" "$BASHRC"; then
   cat >> "$BASHRC" <<EOF
 
 # --- devcontainer setup ---
+# UTF-8 locale so tmux + other tools render Unicode correctly. C.UTF-8 is
+# available in glibc without locale-gen; works on every dev image we use.
+# Without this, tmux mangles non-ASCII bytes on output (em-dash -> "_" etc).
+# See brianholland/dev-common#48.
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
+
 # Conda takes priority over ~/.local/bin to avoid pip packages shadowing conda
 export PATH="\$HOME/miniforge3/bin:\$HOME/.local/bin:\$PATH"
 


### PR DESCRIPTION
Closes #48. Fixes em-dash rendering as underscore inside tmux on devcontainer shells (bare ssh shell renders fine; tmux inherits empty LANG and mangles non-ASCII on output).