### PR TITLE
feat: setup-git-identity.sh (bdh-ai for Claude commits)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.8.0
+VERSION=0.9.0
 
 # Include our own shared targets
 include make/version.mk

--- a/devcontainer/setup-git-identity.sh
+++ b/devcontainer/setup-git-identity.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# setup-git-identity.sh - Set the bdh-ai git identity for Claude commits.
+# Source from your project's .devcontainer/setup.sh AFTER the gitconfig seed
+# copy, so this write is not overwritten by it.
+#
+# Usage:
+#   [ -f "$GITCONFIG_SEED" ] && cp "$GITCONFIG_SEED" "${HOME}/.gitconfig"
+#   source "$COMMON/setup-git-identity.sh"
+#
+# Devcontainers run Claude Code; commits should attribute to bdh-ai (Claude's
+# dedicated GitHub identity), not the host user. Hardcoded for now — see
+# devtemplate#35 for the rationale and dev-common#52 for the rollout.
+
+set -euo pipefail
+
+echo "==> Setting git identity to bdh-ai..."
+git config --global user.name "bdh-ai"
+git config --global user.email "282552773+bdh-ai@users.noreply.github.com"
+echo "    user.name = $(git config --get user.name)"
+echo "    user.email = $(git config --get user.email)"


### PR DESCRIPTION
## Summary

- Add \`devcontainer/setup-git-identity.sh\` that writes \`bdh-ai\` as the git \`user.name\` / \`user.email\` in the container's \`~/.gitconfig\`
- Hardcoded identity (single-tenant for now): \`bdh-ai\` / \`282552773+bdh-ai@users.noreply.github.com\`
- Bump dev-common 0.8.0 → 0.9.0 (new feature)

Closes #52
Refs devtemplate#35

## Why

Devcontainer commits currently attribute to the host user (Brian) because the gitconfig seed mechanism carries the host's \`[user]\` block into the container. The push uses bdh-ai's PAT, but the commit objects have Brian's name + email — confusing audit trail. This script overrides the seed-derived identity so commits attribute to bdh-ai (the GitHub user the PATs are scoped under).

## Consumer wire-up

Each consumer's \`.devcontainer/setup.sh\` adds one line *after* the seed copy:

\`\`\`bash
[ -f \"\$GITCONFIG_SEED\" ] && cp \"\$GITCONFIG_SEED\" \"\${HOME}/.gitconfig\"
source \"\$COMMON/setup-git-identity.sh\"   # NEW
\`\`\`

Order matters — placing it before the seed copy would let the seed overwrite the bdh-ai write.

## Rollout (separate PRs after merge)

- devtemplate (the scaffold) — closes devtemplate#35
- 9 stack-home-site consumers: home-site, panoptikon, hog, freddyb, canary, heller, oleo, refdims, ratecraft

## Test plan

- [ ] Merge this PR
- [ ] Bump dev-common submodule in devtemplate; verify the source line is in scaffold's setup.sh
- [ ] Bump in one consumer (home-site) first; rebuild devcontainer; verify a fresh commit shows \`Author: bdh-ai\`
- [ ] Roll out to remaining 8 consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)