### PR TITLE
feat: setup-claude-identity.sh — Claude gitconfig under ~/.claude/identity/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.8.0
+VERSION=0.9.0
 
 # Include our own shared targets
 include make/version.mk

--- a/devcontainer/setup-claude-identity.sh
+++ b/devcontainer/setup-claude-identity.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# setup-claude-identity.sh - establish Claude's git identity in the container.
+# Bootstraps ~/.claude/identity/.gitconfig if missing (the file persists on
+# the host via the ~/.claude bind mount, so subsequent containers reuse it),
+# then symlinks ~/.gitconfig to it so every git invocation reads the same
+# Claude-attributed config.
+#
+# Usage (from your project's .devcontainer/setup.sh):
+#   source "$COMMON/setup-claude-identity.sh"
+#
+# Replaces the older host-gitconfig-seed mechanism for Claude devcontainers.
+# See devtemplate#35 for rationale and dev-common#54 for rollout.
+
+set -euo pipefail
+
+IDENTITY_DIR="$HOME/.claude/identity"
+GITCONFIG="$IDENTITY_DIR/.gitconfig"
+
+mkdir -p "$IDENTITY_DIR"
+
+if [ ! -f "$GITCONFIG" ]; then
+  echo "==> Bootstrapping Claude gitconfig at $GITCONFIG..."
+  cat > "$GITCONFIG" <<'EOF'
+[user]
+	name = bdh-ai
+	email = 282552773+bdh-ai@users.noreply.github.com
+[init]
+	defaultBranch = main
+[filter "lfs"]
+	clean = git-lfs clean -- %f
+	smudge = git-lfs smudge -- %f
+	process = git-lfs filter-process
+	required = true
+[credential "https://github.com"]
+	helper =
+	helper = !/usr/bin/gh auth git-credential
+[credential "https://gist.github.com"]
+	helper =
+	helper = !/usr/bin/gh auth git-credential
+EOF
+fi
+
+ln -sfn "$GITCONFIG" "$HOME/.gitconfig"
+echo "==> ~/.gitconfig -> $GITCONFIG (bdh-ai identity)"


### PR DESCRIPTION
## Summary

- Add \`devcontainer/setup-claude-identity.sh\` — bootstraps \`~/.claude/identity/.gitconfig\` (host-persistent via the existing \`~/.claude\` bind mount), then symlinks \`~/.gitconfig\` → that file
- Bump dev-common 0.8.0 → 0.9.0 (new feature)

Replaces #53 (closed). Closes #54. Refs devtemplate#35, devtemplate#36.

## What the bootstrapped file contains

Self-contained gitconfig with:
- \`[user]\` — bdh-ai identity (\`282552773+bdh-ai@users.noreply.github.com\`)
- \`[init] defaultBranch = main\` — carried over from existing convention
- \`[filter \"lfs\"]\` — LFS support (matches what was in the host seed)
- \`[credential \"https://github.com\"]\` and \`[credential \"https://gist.github.com\"]\` — \`gh auth git-credential\` helper, so \`git push\` authenticates via the per-call \`GH_TOKEN\` pattern. Bootstrapping inline means the file is self-contained and doesn't require running \`gh auth setup-git\` post-bootstrap.

The file lives on the host at \`~/.claude/identity/.gitconfig\` (not in the workspace, not committed). First container to find it missing creates it; subsequent containers just symlink to it. \`cat ~/.claude/identity/.gitconfig\` on twix is the one place that asserts \"this is who Claude commits as.\"

## Why this design over the previous PR (#53)

#53 wrote \`~/.gitconfig\` directly inside the container. That works but couples identity to container lifecycle and requires the consumer's seed copy to run *before* the override (or get overwritten). This design decouples identity from the container — it's a host-managed file that the container points at.

Forward-compatible with the multi-AI devcontainer concept (devtemplate#36): future waterbrother-or-other-AI containers get their own \`~/.waterbrother/identity/\` sister directory with no overlap.

## Consumer wire-up (separate PRs after this lands)

Each consumer's \`.devcontainer/setup.sh\` swaps the seed-copy line:

\`\`\`diff
- [ -f \"\$GITCONFIG_SEED\" ] && cp \"\$GITCONFIG_SEED\" \"\${HOME}/.gitconfig\"
+ source \"\$COMMON/setup-claude-identity.sh\"
\`\`\`

One-line change per consumer + dev-common submodule bump + version bump. 9 stack-home-site consumers + devtemplate scaffold.

## Cleanup deferred

The host-seed mechanism (\`init-host.sh\` creating \`.devcontainer/.gitconfig.seed\`, the \`GITCONFIG_SEED\` env var in \`env.sh\`) becomes dead code. Leaving it in place for now — sweep folds into dev-common#31's broader devcontainer-setup lift.

## Test plan

- [ ] Merge this PR
- [ ] Pick one consumer (home-site) for the first sweep PR; verify after rebuild that:
  - [ ] \`~/.claude/identity/.gitconfig\` exists on twix (created on first container init)
  - [ ] \`~/.gitconfig\` inside the container is a symlink to it
  - [ ] \`git config --get user.name\` returns \`bdh-ai\`
  - [ ] A test commit pushes successfully and shows as authored by bdh-ai on GitHub
- [ ] Roll out to remaining 8 consumers + devtemplate

🤖 Generated with [Claude Code](https://claude.com/claude-code)