### PR TITLE
feat: Claude identity under ~/.config/ai/claude/ (setup-claude-identity.sh + renamed creds)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.8.0
+VERSION=0.9.0
 
 # Include our own shared targets
 include make/version.mk

--- a/devcontainer/setup-claude-identity.sh
+++ b/devcontainer/setup-claude-identity.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# setup-claude-identity.sh - point ~/.gitconfig and ~/.config/gh at Claude's
+# host-managed identity tree.
+#
+# Identity files live on the host at ~/.config/ai/claude/identity/ and are
+# bind-mounted into the container at the same path. This script symlinks the
+# standard tool locations (~/.gitconfig, ~/.config/gh) into that tree so git
+# and gh find Claude's config at default paths without environment-variable
+# indirection. Bootstraps the identity files on a fresh host.
+#
+# Why ~/.config/ai/claude/ rather than ~/.claude/: ~/.claude/ is Claude Code's
+# own state directory (session creds, project memory, settings). User-curated
+# config for what Claude SHOULD use is separate, under ~/.config/ai/claude/.
+# Forward-compatible with the multi-AI devcontainer concept (devtemplate#36).
+#
+# Usage (from your project's .devcontainer/setup.sh):
+#   source "$COMMON/setup-claude-identity.sh"
+#
+# Replaces the older host-gitconfig-seed mechanism for Claude devcontainers.
+# See devtemplate#35 for rationale and dev-common#54 for rollout.
+
+set -euo pipefail
+
+IDENTITY_DIR="$HOME/.config/ai/claude/identity"
+GITCONFIG="$IDENTITY_DIR/.gitconfig"
+GH_DIR="$IDENTITY_DIR/gh"
+
+mkdir -p "$IDENTITY_DIR" "$GH_DIR"
+
+# Bootstrap gitconfig if missing (fresh-host case; otherwise it's already
+# on the host, bind-mounted in, and we just symlink to it).
+if [ ! -f "$GITCONFIG" ]; then
+  echo "==> Bootstrapping Claude gitconfig at $GITCONFIG..."
+  cat > "$GITCONFIG" <<'EOF'
+[user]
+	name = bdh-ai
+	email = 282552773+bdh-ai@users.noreply.github.com
+[init]
+	defaultBranch = main
+[filter "lfs"]
+	clean = git-lfs clean -- %f
+	smudge = git-lfs smudge -- %f
+	process = git-lfs filter-process
+	required = true
+[credential "https://github.com"]
+	helper =
+	helper = !/usr/bin/gh auth git-credential
+[credential "https://gist.github.com"]
+	helper =
+	helper = !/usr/bin/gh auth git-credential
+EOF
+fi
+
+# Bootstrap gh config.yml if missing.
+if [ ! -f "$GH_DIR/config.yml" ]; then
+  echo "==> Bootstrapping gh config at $GH_DIR/config.yml..."
+  cat > "$GH_DIR/config.yml" <<'EOF'
+# gh CLI preferences for the bdh-ai identity.
+# Auth state is intentionally absent — gh authenticates per call via
+# GH_TOKEN, using the org-scoped PATs at ~/.config/ai/claude/credentials/.
+
+git_protocol: https
+prompt: disabled
+pager: cat
+EOF
+fi
+
+# Point standard tool paths at Claude's identity tree. ln -sfn replaces an
+# existing symlink atomically; for ~/.config/gh we explicitly remove a
+# pre-existing real directory (gh creates one on first invocation if it
+# beat us here).
+ln -sfn "$GITCONFIG" "$HOME/.gitconfig"
+mkdir -p "$HOME/.config"
+if [ -e "$HOME/.config/gh" ] && [ ! -L "$HOME/.config/gh" ]; then
+  rm -rf "$HOME/.config/gh"
+fi
+ln -sfn "$GH_DIR" "$HOME/.config/gh"
+
+echo "==> ~/.gitconfig -> $GITCONFIG"
+echo "==> ~/.config/gh -> $GH_DIR"
+echo "    user.name = $(git config --get user.name)"
+echo "    user.email = $(git config --get user.email)"

--- a/devcontainer/setup-claude.sh
+++ b/devcontainer/setup-claude.sh
@@ -18,8 +18,8 @@ fi
 # Install the claude-prod shim that proxies to the prod wrapper over SSH.
 # The corresponding server-side scripts and one-time setup live in
 # brianholland/home-site:claude-access/.  The private key is expected at
-# ~/.claude/credentials/claude-prod-readonly (the host ~/.claude is bind-
-# mounted into every devcontainer per devtemplate's devcontainer.json).
+# ~/.config/ai/claude/credentials/prod-readonly (host bind-mounted into every
+# devcontainer per the bind mount in devtemplate's devcontainer.json).
 echo "==> Installing claude-prod shim..."
 sudo tee /usr/local/bin/claude-prod >/dev/null <<'CLAUDE_PROD_EOF'
 #!/usr/bin/env bash
@@ -29,7 +29,7 @@ sudo tee /usr/local/bin/claude-prod >/dev/null <<'CLAUDE_PROD_EOF'
 # server-side claude-prod wrapper, which validates against an allowlist.
 set -euo pipefail
 
-KEY="${HOME}/.claude/credentials/claude-prod-readonly"
+KEY="${HOME}/.config/ai/claude/credentials/prod-readonly"
 HOST="${CLAUDE_PROD_HOST:-prod}"
 
 if [[ ! -r "$KEY" ]]; then
@@ -67,7 +67,7 @@ sudo tee /usr/local/bin/claude-dev >/dev/null <<'CLAUDE_DEV_EOF'
 # against an allowlist.
 set -euo pipefail
 
-KEY="${HOME}/.claude/credentials/claude-dev-readonly"
+KEY="${HOME}/.config/ai/claude/credentials/dev-readonly"
 HOST="${CLAUDE_DEV_HOST:-twix}"
 
 if [[ ! -r "$KEY" ]]; then


### PR DESCRIPTION
## Summary

- Add \`devcontainer/setup-claude-identity.sh\` — bootstraps Claude's git + gh config on the host at \`~/.config/ai/claude/identity/\` (if missing) and symlinks \`~/.gitconfig\` + \`~/.config/gh\` into that tree
- Update \`devcontainer/setup-claude.sh\` — claude-prod / claude-dev shims now read SSH keys from \`~/.config/ai/claude/credentials/{prod,dev}-readonly\` (renamed from \`~/.claude/credentials/claude-{prod,dev}-readonly\`)
- Bump dev-common 0.8.0 → 0.9.0

Replaces #55 (closed). Closes #54. Refs devtemplate#35 / devtemplate#36.

## Why \`~/.config/ai/claude/\` rather than \`~/.claude/\`

\`~/.claude/\` is owned by Claude Code itself (session credentials, project memory, settings.json). User-curated config for *what Claude should use* is separate. Putting bdh-ai's identity and PATs under \`~/.claude/\` risked Claude Code rotating its own state and taking the user's curated config with it.

The new tree is forward-compatible with the multi-AI devcontainer concept (devtemplate#36) — future AIs get sister directories: \`~/.config/ai/waterbrother/\`, \`~/.config/ai/<other>/\`. Each AI can be loaded independently with no overlap.

## Layout (host-side, persisted on twix)

\`\`\`
~/.config/ai/claude/
├── identity/
│   ├── .gitconfig          # bdh-ai user + LFS + credential helper
│   └── gh/
│       └── config.yml      # gh prefs (non-auth: protocol/prompt/pager)
└── credentials/
    ├── gh-bdh-org.token
    ├── gh-finzeug.token
    ├── gh-finriskanalytics.token
    ├── prod-readonly{,.pub}
    └── dev-readonly{,.pub}
\`\`\`

## Container access (per-consumer wire-up)

Each consumer's \`.devcontainer/devcontainer.json\` adds a bind mount line:

\`\`\`json
\"source=\${localEnv:HOME}/.config/ai/claude,target=/home/vscode/.config/ai/claude,type=bind,consistency=cached\",
\`\`\`

The existing \`~/.claude\` mount stays (Claude Code's own state).

Each consumer's \`.devcontainer/setup.sh\` swaps the seed-copy line:

\`\`\`diff
- [ -f \"\$GITCONFIG_SEED\" ] && cp \"\$GITCONFIG_SEED\" \"\${HOME}/.gitconfig\"
+ source \"\$COMMON/setup-claude-identity.sh\"
\`\`\`

After consumer rebuild, \`~/.gitconfig\` becomes a symlink to \`~/.config/ai/claude/identity/.gitconfig\` and \`~/.config/gh\` becomes a symlink to \`~/.config/ai/claude/identity/gh\`. Default tool paths just work.

## Identity (hardcoded for now)

- name: \`bdh-ai\`
- email: \`282552773+bdh-ai@users.noreply.github.com\`

Single-tenant. Parameterize via env vars if a second consumer materializes.

## Cleanup deferred

The host-seed mechanism (\`init-host.sh\` creating \`.devcontainer/.gitconfig.seed\`, \`GITCONFIG_SEED\` in \`env.sh\`) becomes dead code under this approach. Leaving in place — sweep folds into dev-common#31's broader devcontainer-setup lift.

## Test plan

- [ ] Merge this PR
- [ ] Pick one consumer (home-site) for the first sweep PR; verify after rebuild that:
  - [ ] \`~/.gitconfig\` is a symlink to \`/home/vscode/.config/ai/claude/identity/.gitconfig\`
  - [ ] \`~/.config/gh\` is a symlink to \`/home/vscode/.config/ai/claude/identity/gh\`
  - [ ] \`git config --get user.name\` returns \`bdh-ai\`
  - [ ] \`gh api user --jq .login\` returns \`bdh-ai\` (with GH_TOKEN env)
  - [ ] A test commit pushes successfully and shows as authored by bdh-ai on GitHub
  - [ ] \`claude-prod docker-ps\` works (verifies new SSH key path)
- [ ] Roll out to remaining 8 consumers + devtemplate
- [ ] Remove migration cp's from \`~/.claude/credentials/\` on twix

🤖 Generated with [Claude Code](https://claude.com/claude-code)