### PR TITLE
chore: bring canonical init-host.sh + README example up to date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.9.0
+VERSION=0.9.1
 
 # Include our own shared targets
 include make/version.mk

--- a/devcontainer/README.md
+++ b/devcontainer/README.md
@@ -93,8 +93,10 @@ Each project maintains its own `conda-packages.txt` with project-specific depend
     "--name=dc-my-project"
   ],
   "mounts": [
-    "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached"
+    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.claude.json,target=/home/vscode/.claude.json,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.config/ai/claude,target=/home/vscode/.config/ai/claude,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.config/ai/xai,target=/home/vscode/.config/ai/xai,type=bind,consistency=cached"
   ],
   "remoteEnv": {
     "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",

--- a/devcontainer/init-host.sh
+++ b/devcontainer/init-host.sh
@@ -5,18 +5,15 @@
 # that macOS stores in the Keychain rather than on disk.
 set -euo pipefail
 
-mkdir -p "${HOME}/.config/gh" "${HOME}/.claude" "${HOME}/data"
+mkdir -p "${HOME}/.claude" "${HOME}/.config/ai/claude/identity/gh" "${HOME}/.config/ai/claude/credentials" "${HOME}/data"
 
 # Save host hostname for the container to use
 hostname > "$(dirname "$0")/.hostname"
 
-# Ensure ~/.gitconfig exists so the bind mount doesn't fail.
-[ -f "${HOME}/.gitconfig" ] || touch "${HOME}/.gitconfig"
-
-# Ensure these files exist so the bind mount doesn't fail.
+# Ensure these files exist so bind mounts don't fail.
 # Docker requires the source file to exist for file-level bind mounts.
 [ -f "${HOME}/.claude.json" ] || touch "${HOME}/.claude.json"
-mkdir -p "${HOME}/.config/xai"
+mkdir -p "${HOME}/.config/ai/xai"
 
 # macOS: Claude Code stores OAuth tokens in the system Keychain,
 # not in ~/.claude/.credentials.json. Extract them so the bind


### PR DESCRIPTION
The reference template in this repo lagged behind devtemplate's actual files. Bring both in line:

- \`devcontainer/init-host.sh\` -- dropped \`~/.config/gh\` mkdir (gh mount removed long ago), swapped \`~/.config/xai\` -> \`~/.config/ai/xai\` per dotconfig layout, added the \`~/.config/ai/claude/{identity/gh,credentials}\` dirs from the Claude identity migration
- \`devcontainer/README.md\` example devcontainer.json -- removed \`~/.config/gh\` mount, added the now-standard \`~/.config/ai/claude\`, \`~/.config/ai/xai\`, \`~/.claude.json\` mounts

Pure docs/template cleanup -- no consumer impact (each consumer repo has its own actual init-host.sh).

Closes #57. Context: brianholland/home-site#142.