### PR TITLE
feat: make bump-* sync package.json + package-lock.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.9.1
+VERSION=0.9.2
 
 # Include our own shared targets
 include make/version.mk

--- a/make/version.mk
+++ b/make/version.mk
@@ -10,32 +10,43 @@ tag: ## create git tag for current VERSION
 	git tag $(VERSION)
 	git push origin $(VERSION)
 
-bump-patch: ## bump patch version (x.y.Z) and commit
-	@NEW_VERSION=$$(echo $(VERSION) | awk -F. '{print $$1"."$$2"."$$3+1}') && \
+# Implementation note: the bump-* targets all do the same rewrite work
+# for the same set of files; only NEW_VERSION differs. We compute it,
+# then call _bump_apply to do the substitutions.
+#
+# Files touched (each conditional on existence + relevant field):
+#   - Makefile (VERSION= line)
+#   - $(PACKAGE_DIR)/__init__.py (__version__ = "...") -- Python projects
+#   - package.json ("version": "...") -- Node/Vite projects
+#   - package-lock.json (top-level + packages[""] "version") -- if present
+
+define _bump_apply
 	$(SED_I) "s/VERSION=$(VERSION)/VERSION=$$NEW_VERSION/" Makefile && \
-	[ -f $(PACKAGE_DIR)/__init__.py ] && grep -q '__version__' $(PACKAGE_DIR)/__init__.py && \
-		$(SED_I) 's/__version__ = ".*"/__version__ = "'"$$NEW_VERSION"'"/' $(PACKAGE_DIR)/__init__.py && \
-		git add $(PACKAGE_DIR)/__init__.py || true && \
 	git add Makefile && \
+	if [ -f $(PACKAGE_DIR)/__init__.py ] && grep -q '__version__' $(PACKAGE_DIR)/__init__.py; then \
+		$(SED_I) 's/__version__ = ".*"/__version__ = "'"$$NEW_VERSION"'"/' $(PACKAGE_DIR)/__init__.py && \
+		git add $(PACKAGE_DIR)/__init__.py; \
+	fi && \
+	if [ -f package.json ] && grep -q '"version"' package.json; then \
+		$(SED_I) 's/"version": *"[^"]*"/"version": "'"$$NEW_VERSION"'"/' package.json && \
+		git add package.json; \
+	fi && \
+	if [ -f package-lock.json ] && grep -q '"version"' package-lock.json; then \
+		$(SED_I) '1,12 s/"version": *"[^"]*"/"version": "'"$$NEW_VERSION"'"/' package-lock.json && \
+		git add package-lock.json; \
+	fi && \
 	git commit -m "chore: bump version to $$NEW_VERSION" && \
 	echo "Bumped to $$NEW_VERSION"
+endef
+
+bump-patch: ## bump patch version (x.y.Z) and commit
+	@NEW_VERSION=$$(echo $(VERSION) | awk -F. '{print $$1"."$$2"."$$3+1}') && \
+	$(call _bump_apply)
 
 bump-minor: ## bump minor version (x.Y.0) and commit
 	@NEW_VERSION=$$(echo $(VERSION) | awk -F. '{print $$1"."$$2+1".0"}') && \
-	$(SED_I) "s/VERSION=$(VERSION)/VERSION=$$NEW_VERSION/" Makefile && \
-	[ -f $(PACKAGE_DIR)/__init__.py ] && grep -q '__version__' $(PACKAGE_DIR)/__init__.py && \
-		$(SED_I) 's/__version__ = ".*"/__version__ = "'"$$NEW_VERSION"'"/' $(PACKAGE_DIR)/__init__.py && \
-		git add $(PACKAGE_DIR)/__init__.py || true && \
-	git add Makefile && \
-	git commit -m "chore: bump version to $$NEW_VERSION" && \
-	echo "Bumped to $$NEW_VERSION"
+	$(call _bump_apply)
 
 bump-major: ## bump major version (X.0.0) and commit
 	@NEW_VERSION=$$(echo $(VERSION) | awk -F. '{print $$1+1".0.0"}') && \
-	$(SED_I) "s/VERSION=$(VERSION)/VERSION=$$NEW_VERSION/" Makefile && \
-	[ -f $(PACKAGE_DIR)/__init__.py ] && grep -q '__version__' $(PACKAGE_DIR)/__init__.py && \
-		$(SED_I) 's/__version__ = ".*"/__version__ = "'"$$NEW_VERSION"'"/' $(PACKAGE_DIR)/__init__.py && \
-		git add $(PACKAGE_DIR)/__init__.py || true && \
-	git add Makefile && \
-	git commit -m "chore: bump version to $$NEW_VERSION" && \
-	echo "Bumped to $$NEW_VERSION"
+	$(call _bump_apply)


### PR DESCRIPTION
Closes #59. Refactors bump-{patch,minor,major} to share a `_bump_apply` macro and extends it with package.json + package-lock.json handling. No behavior change for Python-only repos; Node/Vite repos (oleo) stay aligned automatically going forward. The lockfile edit is scoped to lines 1-12 so nested dependency versions are untouched. Verified by self-bump on dev-common (no package.json, only Makefile bumped).