### PR TITLE
feat: version-check to prevent Makefile/__version__ drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Clone dev-common submodule
         run: git submodule update --init common
 
+      - name: Version consistency
+        run: make version-check
+
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.9.2
+VERSION=0.9.3
 
 # Include our own shared targets
 include make/version.mk

--- a/make/version.mk
+++ b/make/version.mk
@@ -4,11 +4,29 @@
 # Portable sed in-place: macOS requires -i '', GNU requires -i
 SED_I := $(shell if sed --version 2>/dev/null | grep -q GNU; then echo 'sed -i'; else echo 'sed -i ""'; fi)
 
-.PHONY: tag bump-patch bump-minor bump-major
+.PHONY: tag bump-patch bump-minor bump-major version-check
 
 tag: ## create git tag for current VERSION
 	git tag $(VERSION)
 	git push origin $(VERSION)
+
+# Fail if the Makefile VERSION disagrees with any other version string in the
+# repo (Python __version__, package.json). The bump-* targets keep these in
+# sync, but a manual sed/edit (or a partial bump) can drift them -- this
+# target, run in CI, makes that drift a red build instead of a silent bug.
+# No-op for repos that have neither file.
+version-check: ## fail if VERSION disagrees with __version__ / package.json
+	@fail=0; \
+	if [ -n "$(PACKAGE_DIR)" ] && [ -f "$(PACKAGE_DIR)/__init__.py" ] && grep -q '__version__' "$(PACKAGE_DIR)/__init__.py"; then \
+		pv=`grep -m1 '__version__' "$(PACKAGE_DIR)/__init__.py" | sed -E 's/.*=[[:space:]]*"([^"]*)".*/\1/'`; \
+		if [ "$$pv" != "$(VERSION)" ]; then echo "version drift: Makefile VERSION=$(VERSION) but $(PACKAGE_DIR)/__init__.py __version__=$$pv" >&2; fail=1; fi; \
+	fi; \
+	if [ -f package.json ] && grep -q '"version"' package.json; then \
+		jv=`grep -m1 '"version"' package.json | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/'`; \
+		if [ "$$jv" != "$(VERSION)" ]; then echo "version drift: Makefile VERSION=$(VERSION) but package.json version=$$jv" >&2; fail=1; fi; \
+	fi; \
+	if [ "$$fail" = 0 ]; then echo "version-check OK ($(VERSION))"; \
+	else echo "Fix so all version strings match (re-run 'make bump-patch', or edit by hand)." >&2; exit 1; fi
 
 # Implementation note: the bump-* targets all do the same rewrite work
 # for the same set of files; only NEW_VERSION differs. We compute it,


### PR DESCRIPTION
Version strings drift silently today: `bump-*` syncs Makefile VERSION ->
`__version__`/package.json, but a manual `sed`/edit (or partial bump)
bypasses it. Found in prod: **hog** Makefile 0.6.96 vs `__version__` 0.6.92,
and **oleo** with *three* different versions (Makefile 0.7.57, `__version__`
0.7.45, package.json 0.7.39). The stale API `__version__` already caused a
deploy mis-diagnosis.

## Change
- `version.mk`: new `version-check` target — fails if Makefile `VERSION`
  disagrees with `$(PACKAGE_DIR)/__init__.py __version__` or package.json
  `version`. No-op for repos that have neither.
- `ci.yml`: run `make version-check` (right after the submodule clone, before
  any installs — fast fail).

Now drift is a red build regardless of how VERSION was changed. Verified the
target passes clean, catches hog's 0.6.96-vs-0.6.92 drift, and passes when
matched.

Consuming repos pick this up on their next `common` submodule bump. The two
current drifts are corrected in companion PRs (finzeug/hog, finzeug/oleo).