### PR TITLE
feat: per-container ~/.claude.json instead of shared host mount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.9.3
+VERSION=0.10.0
 
 # Include our own shared targets
 include make/version.mk

--- a/devcontainer/README.md
+++ b/devcontainer/README.md
@@ -58,6 +58,8 @@ source "$COMMON/setup-python-dev.sh" "conda-packages.txt" # with project package
 Claude Code CLI setup:
 
 - Installs Claude Code CLI via native installer (curl)
+- Seeds a private `~/.claude.json` (onboarding stub) if absent, so each
+  container keeps its own Claude Code state instead of sharing the host file
 
 ### setup-waterbrother.sh
 
@@ -94,7 +96,6 @@ Each project maintains its own `conda-packages.txt` with project-specific depend
   ],
   "mounts": [
     "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.claude.json,target=/home/vscode/.claude.json,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.config/ai/claude,target=/home/vscode/.config/ai/claude,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.config/ai/xai,target=/home/vscode/.config/ai/xai,type=bind,consistency=cached"
   ],

--- a/devcontainer/init-host.sh
+++ b/devcontainer/init-host.sh
@@ -10,9 +10,9 @@ mkdir -p "${HOME}/.claude" "${HOME}/.config/ai/claude/identity/gh" "${HOME}/.con
 # Save host hostname for the container to use
 hostname > "$(dirname "$0")/.hostname"
 
-# Ensure these files exist so bind mounts don't fail.
-# Docker requires the source file to exist for file-level bind mounts.
-[ -f "${HOME}/.claude.json" ] || touch "${HOME}/.claude.json"
+# Ensure bind-mount source dirs exist (Docker fails if a mount source is
+# missing). Note: ~/.claude.json is intentionally NOT created/mounted anymore
+# — each container seeds its own copy in setup-claude.sh.
 mkdir -p "${HOME}/.config/ai/xai"
 
 # macOS: Claude Code stores OAuth tokens in the system Keychain,

--- a/devcontainer/setup-claude.sh
+++ b/devcontainer/setup-claude.sh
@@ -15,6 +15,17 @@ else
   echo "    Claude Code CLI already installed"
 fi
 
+# Seed a minimal ~/.claude.json so per-container Claude Code skips first-run
+# onboarding. The host ~/.claude.json is no longer bind-mounted (sharing one
+# file across containers caused concurrent-write corruption); each container
+# now owns its own copy. Only seed when absent/empty so real state is never
+# clobbered (e.g. if a repo still mounts the host file).
+if [ ! -s "${HOME}/.claude.json" ]; then
+  echo '{"hasCompletedOnboarding":true,"installMethod":"native"}' > "${HOME}/.claude.json"
+  chmod 600 "${HOME}/.claude.json"
+  echo "    seeded ${HOME}/.claude.json onboarding stub"
+fi
+
 # Install the claude-prod shim that proxies to the prod wrapper over SSH.
 # The corresponding server-side scripts and one-time setup live in
 # brianholland/home-site:claude-access/.  The private key is expected at


### PR DESCRIPTION
Foundation for bdh-org/devtemplate#41.

Stops relying on the shared host `~/.claude.json` bind mount:
- `setup-claude.sh`: seeds a private `~/.claude.json` onboarding stub (`{"hasCompletedOnboarding":true,...}`) when absent/empty, so each container keeps its own Claude Code state and skips first-run onboarding.
- `init-host.sh`: removes the `touch ~/.claude.json` (the file is no longer mounted).
- `README.md`: drops the mount from the example, documents the seed.
- Version 0.9.3 -> 0.10.0.

Consumers pick this up via a `common` submodule bump (the propagation step). Takes effect on next `make dc-nuke && make dc-up`.