### PR TITLE
fix: seed full Claude identity into per-container ~/.claude.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.0
+VERSION=0.10.1
 
 # Include our own shared targets
 include make/version.mk

--- a/devcontainer/init-host.sh
+++ b/devcontainer/init-host.sh
@@ -15,6 +15,30 @@ hostname > "$(dirname "$0")/.hostname"
 # — each container seeds its own copy in setup-claude.sh.
 mkdir -p "${HOME}/.config/ai/xai"
 
+# Extract the stable identity/onboarding keys from the host ~/.claude.json
+# into a seed file inside the mounted ~/.claude dir. setup-claude.sh copies it
+# to the container-private ~/.claude.json so fresh containers skip the welcome
+# flow: Claude Code's logged-in check needs oauthAccount/userID in
+# ~/.claude.json, not just the tokens in ~/.claude/.credentials.json.
+if [ -s "${HOME}/.claude.json" ]; then
+  if python3 - "${HOME}/.claude.json" "${HOME}/.claude/.claude.json.seed" <<'PYEOF'
+import json, sys
+keep = ("hasCompletedOnboarding", "installMethod", "theme",
+        "oauthAccount", "userID", "lastOnboardingVersion")
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+seed = {k: data[k] for k in keep if k in data}
+seed["hasCompletedOnboarding"] = True
+with open(sys.argv[2], "w") as f:
+    json.dump(seed, f)
+PYEOF
+  then
+    chmod 600 "${HOME}/.claude/.claude.json.seed"
+  else
+    echo "WARN: could not extract ~/.claude/.claude.json.seed; fresh containers will prompt for login" >&2
+  fi
+fi
+
 # macOS: Claude Code stores OAuth tokens in the system Keychain,
 # not in ~/.claude/.credentials.json. Extract them so the bind
 # mount makes them available inside the container.

--- a/devcontainer/setup-claude.sh
+++ b/devcontainer/setup-claude.sh
@@ -8,22 +8,33 @@
 set -euo pipefail
 
 echo "==> Setting up Claude Code CLI..."
+
+# Seed ~/.claude.json so per-container Claude Code skips first-run onboarding.
+# The host ~/.claude.json is no longer bind-mounted (sharing one file across
+# containers caused concurrent-write corruption); each container now owns its
+# own copy. Prefer the seed file that init-host.sh extracts from the host's
+# ~/.claude.json into the mounted ~/.claude dir: the logged-in check needs the
+# identity fields (oauthAccount, userID) in ~/.claude.json, not just tokens in
+# ~/.claude/.credentials.json — without them Claude Code runs the full welcome
+# flow (theme + login) despite hasCompletedOnboarding. Only seed when absent/
+# empty so real state is never clobbered, and do it before the CLI install so
+# no first run can beat the seed.
+if [ ! -s "${HOME}/.claude.json" ]; then
+  if [ -s "${HOME}/.claude/.claude.json.seed" ]; then
+    cp "${HOME}/.claude/.claude.json.seed" "${HOME}/.claude.json"
+    echo "    seeded ${HOME}/.claude.json from ~/.claude/.claude.json.seed"
+  else
+    echo '{"hasCompletedOnboarding":true,"installMethod":"native"}' > "${HOME}/.claude.json"
+    echo "    seeded ${HOME}/.claude.json minimal stub (no seed file; login will be prompted)"
+  fi
+  chmod 600 "${HOME}/.claude.json"
+fi
+
 if ! command -v claude >/dev/null 2>&1; then
   curl -fsSL https://claude.ai/install.sh | bash
   echo "    Claude Code CLI installed"
 else
   echo "    Claude Code CLI already installed"
-fi
-
-# Seed a minimal ~/.claude.json so per-container Claude Code skips first-run
-# onboarding. The host ~/.claude.json is no longer bind-mounted (sharing one
-# file across containers caused concurrent-write corruption); each container
-# now owns its own copy. Only seed when absent/empty so real state is never
-# clobbered (e.g. if a repo still mounts the host file).
-if [ ! -s "${HOME}/.claude.json" ]; then
-  echo '{"hasCompletedOnboarding":true,"installMethod":"native"}' > "${HOME}/.claude.json"
-  chmod 600 "${HOME}/.claude.json"
-  echo "    seeded ${HOME}/.claude.json onboarding stub"
 fi
 
 # Install the claude-prod shim that proxies to the prod wrapper over SSH.


### PR DESCRIPTION
## Summary
- The 0.10.0 minimal onboarding stub does not prevent the welcome flow: Claude Code's logged-in check requires `oauthAccount`/`userID` in `~/.claude.json`, not just tokens in `~/.claude/.credentials.json`, so fresh containers still prompted for theme + login.
- `init-host.sh` (runs on HOST) now extracts the stable identity/onboarding keys (`hasCompletedOnboarding`, `installMethod`, `theme`, `oauthAccount`, `userID`, `lastOnboardingVersion`) from the host `~/.claude.json` into `~/.claude/.claude.json.seed`, which rides the existing `~/.claude` bind mount.
- `setup-claude.sh` copies that seed to the container-private `~/.claude.json` when present (falling back to the minimal stub), and seeds BEFORE the CLI install so no first run can beat it.
- Containers never write the seed file, so the concurrent-write corruption fixed in #62 stays fixed.

Closes #63

## Test plan
- `bash -n` on both scripts
- Verified seed extraction logic against a real host-shaped `~/.claude.json`
- Real-world check: next `dc-nuke && dc-up` of a consuming repo should land in Claude Code with no theme/login prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)