### PR TITLE
feat: split CLAUDE.md into generic + stack layers; version-control shared skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,11 @@ writes.
 
 ## Stack Architecture Patterns
 
+These are generic pattern *definitions* — the shared vocabulary for how a stack
+built on this tooling is wired. Each stack's concrete instances (primary repo,
+service names, shared network, hosts) live in that stack's
+`stack-common/CLAUDE.md`, included alongside this file.
+
 ### P1: Primary repo
 Primary/edge repo for a stack. Two hats:
 - **Orchestrator**: owns `docker-compose.yml`, is the entry point for
@@ -61,21 +66,18 @@ Primary/edge repo for a stack. Two hats:
 Has no Python application code of its own, so it does NOT use the shared
 Python CI workflow (`common/.github/workflows/ci.yml`) — ruff + pytest
 don't apply. A P1-shaped CI (compose config validation, vhost syntax
-checks, hadolint) is optional and bespoke.
-
-Example: `home-site` — Apache container on port 80, serves `html/`,
-mounts `oleo/dist` into `/usr/local/apache2/oleo`, proxies panoptikon /
-freddyb / canary / hog.
+checks, hadolint) is optional and bespoke. See stack-common for this
+stack's primary repo.
 
 ### P2a: Full service
 Long-running container (API, dashboard) with its own Dockerfile, served via
-Apache vhost proxy. Examples: panoptikon, freddyb, canary, hog.
+Apache vhost proxy. See stack-common for this stack's services.
 
 ### P2b: Static site
 Built frontend assets (no container of its own). The primary repo's
 Apache container mounts the build output into its docroot via
-`docker-compose.yml` (e.g. `../oleo/dist:/usr/local/apache2/oleo:ro`).
-Example: oleo.
+`docker-compose.yml` (e.g. `../<site>/dist:/usr/local/apache2/<site>:ro`).
+See stack-common for this stack's static sites.
 
 ### P2c: Data service
 Postgres (or similar DB) container whose primary deliverable is
@@ -91,24 +93,25 @@ Postgres (or similar DB) container whose primary deliverable is
   `src/` tree. Devcontainer uses a non-Python base image with
   `docker-outside-of-docker` so the dev can build and run the service.
 
-Example: `entities` (reference data for the finzeug stack).
-
 P2c repos are not currently scaffolded from `devtemplate` cleanly — see
 `brianholland/devtemplate#15` for the `devtemplate-db` sibling template
 that will. Until that exists, P2c repos don't track
-`DEVTEMPLATE_VERSION`.
+`DEVTEMPLATE_VERSION`. See stack-common for this stack's data services.
 
 ### P3: Submodule hierarchy
 Two-tier shared infrastructure via git submodules:
-- `common/` (dev-common) — dev tooling used by all projects: version.mk,
-  python.mk, utils.mk, devcontainer.mk, devcontainer setup scripts (incl.
-  generic `claude-prod` / `claude-dev` shims that read host config from env).
-- `stack-common/` (home-site-common) — stack-specific: deploy.mk, airflow.mk,
+- `common/` (dev-common) — dev tooling used by all projects across every
+  stack: version.mk, python.mk, utils.mk, devcontainer.mk, devcontainer
+  setup scripts (incl. generic `claude-prod` / `claude-dev` shims that read
+  host config from env), and shared Claude Code skills (P14).
+- `stack-common/` — stack-specific: deploy.mk, airflow.mk,
   `devcontainer/setup-stack-hosts.sh` (writes a `/etc/profile.d` entry setting
-  CLAUDE_PROD_HOST / CLAUDE_DEV_HOST and any other stack-specific env). Has
-  dev-common as a nested submodule.
+  CLAUDE_PROD_HOST / CLAUDE_DEV_HOST and any other stack-specific env), and the
+  stack's `CLAUDE.md`. Has dev-common as a nested submodule.
 
-All repos include both with `-include` (tolerates missing submodules on fresh clone).
+All repos include both with `-include` (tolerates missing submodules on fresh
+clone). A repo's `CLAUDE.md` likewise includes `@common/CLAUDE.md` and, when
+present, `@stack-common/CLAUDE.md`.
 
 ### P4: Conda-dev / pip-prod dependency split
 Development and production use different package managers:
@@ -122,13 +125,14 @@ Never delete one thinking it duplicates the other — they serve different purpo
 ### P5: Service composition via extends
 The primary repo's `docker-compose.yml` uses `extends` to pull service
 definitions from stub files in each service's directory
-(e.g. `./panoptikon/docker-compose.stub.yml`). All services join the shared
-`minerva` bridge network.
+(e.g. `./<svc>/docker-compose.stub.yml`). All services join the stack's
+shared bridge network (named in stack-common).
 
 ### P6: Service discovery
-Services find each other by container name on the minerva Docker network
-(e.g. `http://freddyb:8000`, `http://hog:8000`). Environment variables like
-`FBENDPOINT` and `HOG_ENDPOINT` pass these URLs to services that need them.
+Services find each other by container name on the stack's shared Docker
+network. Environment variables pass these URLs to services that need them
+(one endpoint var per upstream). See stack-common for the network name and
+concrete service endpoints.
 
 ### P7: DAG management
 DAGs live in each service's `dags/` directory. `make dags-install` (airflow.mk)
@@ -151,13 +155,13 @@ Four sequential steps initialize the development environment:
 2. `setup-base.sh` — installs Miniforge, tmux, shell config, git aliases.
 3. `setup-python-dev.sh` — conda dev tools (ruff, pytest, jupyter) + project
    packages from `conda-packages.txt`.
-4. `setup-claude.sh` — Claude Code CLI.
+4. `setup-claude.sh` — Claude Code CLI + shared skills (P14).
 5. `setup-waterbrother.sh` — waterbrother CLI (optional; projects that
    don't need it simply don't source this script).
 
 Repos without a Python environment skip step 3:
-- P1 (e.g. `home-site`) — orchestrator + Apache, no Python app code.
-- P2c (e.g. `entities`) — DB service, no Python env in the container.
+- P1 — orchestrator + Apache, no Python app code.
+- P2c — DB service, no Python env in the container.
 
 ### P10: Production deployment with retry
 `prod-deploy-all` deploys the full stack from the primary repo via SSH.
@@ -179,11 +183,11 @@ tracked at `brianholland/devtemplate#24` and `#25`.
 
 ### P12: Dev tier on a parallel host
 A pre-prod environment that mirrors prod's service set on a separate
-host (typically the host that runs the developer's devcontainer, e.g.
-`twix`). Validates cross-service wiring before promoting to prod.
+host (typically the host that runs the developer's devcontainer).
+Validates cross-service wiring before promoting to prod.
 
 Shape, parallel to P10:
-- `dev-deploy-all` SSHes to `$(DEV_SERVER)` (default `twix`, overridable),
+- `dev-deploy-all` SSHes to `$(DEV_SERVER)` (default set by the stack, overridable),
   runs `dev-bootstrap && dev-up` on that host.
 - `dev-bootstrap` is idempotent: copies missing per-service `.env` from
   `.env.example`, seeds host-local data files (e.g. hog's tensor.duckdb)
@@ -195,9 +199,9 @@ Shape, parallel to P10:
   driven by DAGs propagate from prod into dev "for free" through the
   shared NFS mount of prod data.
 
-Apache vhost on the dev host accepts both `*.minerva` (prod) and `*.twix`
-(dev) ServerAlias entries — same image runs on both hosts; only the
-hostname differs.
+Apache vhost on the dev host accepts both prod and dev ServerAlias entries —
+same image runs on both hosts; only the hostname differs. See stack-common
+for the concrete host names and DNS suffixes.
 
 ### P13: Scoped Claude Code identities
 Each tier has a constrained `claude` SSH user — `claude-prod` on prod,
@@ -215,5 +219,16 @@ vars `CLAUDE_PROD_HOST` / `CLAUDE_DEV_HOST` name. stack-common's
 `setup-stack-hosts.sh` writes those env vars at `/etc/profile.d` so they
 survive devcontainer rebuilds.
 
-Source for the wrappers + install docs lives in the primary repo at
-`claude-access/` (e.g. `home-site/claude-access/`).
+Source for the wrappers + install docs lives in the stack's primary repo at
+`claude-access/`.
+
+### P14: Shared Claude Code skills
+Reusable Claude Code skills live in `dev-common/skills/<name>/SKILL.md`
+(version-controlled, one source of truth). `setup-claude.sh` symlinks each
+into `~/.claude/skills/` so they are available in every repo's Claude Code
+session and survive devcontainer rebuilds. Current skills: `ship` (end-to-end
+issue -> PR -> squash-merge -> cleanup), `update-common` (bump the dev-common
+submodule across repos), `incorporate-devtemplate` (diff repos against
+devtemplate, file issues). `make incorporate-devtemplate` is a signpost that
+points at the skill — the work needs human judgment, so there is no
+fully-automated target.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.2
+VERSION=0.10.3
 
 # Include our own shared targets
 include make/version.mk

--- a/devcontainer/setup-claude.sh
+++ b/devcontainer/setup-claude.sh
@@ -37,6 +37,26 @@ else
   echo "    Claude Code CLI already installed"
 fi
 
+# Install shared Claude Code skills from dev-common/skills/ into ~/.claude/skills/
+# (P14). They are version-controlled here (one source of truth) and symlinked, so
+# a `make common-update` is immediately reflected in every repo's Claude Code
+# session and the skills survive devcontainer rebuilds. The symlink replaces any
+# stale real copy left over from when these lived only in ~/.claude/skills/.
+echo "==> Installing shared Claude Code skills..."
+SKILLS_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills"
+if [ -d "$SKILLS_SRC" ]; then
+  mkdir -p "${HOME}/.claude/skills"
+  for d in "$SKILLS_SRC"/*/; do
+    [ -d "$d" ] || continue
+    name="$(basename "$d")"
+    rm -rf "${HOME}/.claude/skills/${name}"
+    ln -s "${SKILLS_SRC}/${name}" "${HOME}/.claude/skills/${name}"
+    echo "    linked skill: ${name}"
+  done
+else
+  echo "    no skills/ dir at $SKILLS_SRC (skipping)"
+fi
+
 # Install the claude-prod shim that proxies to the prod wrapper over SSH.
 # The corresponding server-side scripts and one-time setup live in
 # brianholland/home-site:claude-access/.  The private key is expected at

--- a/make/utils.mk
+++ b/make/utils.mk
@@ -12,7 +12,7 @@ endif
 show: ## Show the commands a target would run (usage: make show <target>)
 	+@$(if $(_SHOW_TARGETS),true,echo "Usage: make show <target>")
 
-.PHONY: help list ls show claude-install common-update prod-clean dev-clean recreate
+.PHONY: help list ls show claude-install common-update incorporate-devtemplate prod-clean dev-clean recreate
 
 help: ## Show available targets with descriptions
 	@for f in $(MAKEFILE_LIST); do \
@@ -42,6 +42,17 @@ common-update: ## update dev-common submodule to latest
 	git add common && \
 	(git diff --cached --quiet common || git commit -m "[CC] chore: update dev-common") && \
 	echo "dev-common is up to date"
+
+# Signpost only: incorporating devtemplate improvements needs human judgment
+# (each repo has bespoke customizations), so there is no automated target. This
+# points at the Claude Code skill that does the diff + files issues (P14).
+incorporate-devtemplate: ## (signpost) run the /incorporate-devtemplate Claude Code skill
+	@echo "Incorporating devtemplate improvements needs human judgment, so there"
+	@echo "is no automated make target. In Claude Code, run:"
+	@echo ""
+	@echo "    /incorporate-devtemplate"
+	@echo ""
+	@echo "It diffs each repo against devtemplate and files issues for missing changes."
 
 PROD_SERVER ?= min
 DEV_SERVER ?= twix

--- a/skills/incorporate-devtemplate/SKILL.md
+++ b/skills/incorporate-devtemplate/SKILL.md
@@ -1,0 +1,116 @@
+Compare repos against devtemplate and create GitHub issues for missing template improvements.
+
+## Instructions
+
+This skill compares each repo's devcontainer config files against the current devtemplate and files issues for missing improvements. It does NOT apply changes automatically — each repo has bespoke customizations that require human judgment.
+
+### 1. Read devtemplate reference files
+
+Read these files from `/workspaces/devtemplate/` to establish the current template state:
+
+- `.devcontainer/devcontainer.json`
+- `.devcontainer/init-host.sh`
+- `.devcontainer/setup.sh`
+- `Makefile` (just the includes and key targets)
+- `conda-packages.txt`
+
+Note the devtemplate version from `Makefile` line 1 (`VERSION=x.y.z`).
+
+### 2. Identify repos
+
+Find all git repos under /workspaces that have a `.devcontainer/` directory, excluding `devtemplate` and `dev-common` themselves.
+
+### 3. Check version tracking
+
+Each repo should have `DEVTEMPLATE_VERSION=x.y.z` in its Makefile (on line 2, after `VERSION`). This records the last devtemplate version that was incorporated.
+
+- If `DEVTEMPLATE_VERSION` is missing, the repo has never tracked this — include adding it as the first checklist item.
+- If `DEVTEMPLATE_VERSION` matches the current devtemplate `VERSION`, skip the repo (already current).
+- If `DEVTEMPLATE_VERSION` is behind, diff and generate the issue.
+
+### 4. For each repo, diff against devtemplate
+
+Compare each repo's config files against devtemplate. Focus on **additive changes in devtemplate that the repo is missing** — things the template has that the repo doesn't. Ignore:
+
+- Repo-specific customizations (extra mounts, API keys, forwarded ports)
+- The `"name"` field and container name in devcontainer.json
+- `PROJECT_NAME` in setup.sh
+- Differences that are intentional per-repo (e.g., Python version pinned for compatibility)
+
+Common categories of missing improvements:
+
+#### devcontainer.json
+- Missing `features` entries (e.g., node feature)
+- Missing `remoteEnv` variables (e.g., XAI_API_KEY)
+- Missing `mounts` from template (e.g., xai config dir)
+- Python image version behind template
+
+#### init-host.sh
+- Missing `mkdir -p` for new config dirs
+- Missing credential extraction steps
+
+#### setup.sh
+- Missing setup script sources
+- Different setup script patterns
+
+### 5. Check for existing open issues
+
+Before creating an issue, check if the repo already has an open issue with "devtemplate" or "Incorporate devtemplate" in the title:
+
+```bash
+gh issue list --state open --search "devtemplate" --limit 5
+```
+
+If an existing issue exists, update its body with the current diff instead of creating a duplicate. Use `gh issue edit <number> --body "..."`.
+
+### 6. Create or update issue per repo
+
+For each repo that has missing improvements, create (or update) a GitHub issue:
+
+**Title:** `Incorporate devtemplate v{VERSION} improvements`
+
+**Body format:**
+```markdown
+## Summary
+Devtemplate has been updated with several improvements that should be incorporated into this repo.
+
+## Changes needed
+
+- [ ] Add `DEVTEMPLATE_VERSION=x.y.z` to Makefile (line 2, after VERSION) ← only if missing
+- [ ] {specific change 1}
+- [ ] {specific change 2}
+...
+
+## Closing this issue
+When all items are done, set `DEVTEMPLATE_VERSION={VERSION}` in the Makefile to record that this version has been incorporated.
+
+## Notes
+- Review each item — some may not apply to this repo
+- Repo-specific customizations should be preserved
+```
+
+Each checklist item should be specific and actionable, e.g.:
+- `Add DEVTEMPLATE_VERSION=0.6.3 to Makefile (line 2, after VERSION)`
+- `Add Node.js devcontainer feature ("ghcr.io/devcontainers/features/node:1": {}) to devcontainer.json`
+- `Add XAI_API_KEY to remoteEnv in devcontainer.json`
+- `Add ~/.config/xai mount to devcontainer.json`
+- `Add mkdir -p "${HOME}/.config/xai" to init-host.sh`
+- `Update Python image from 3.12 to 3.13 in devcontainer.json`
+- `Update DEVTEMPLATE_VERSION to 0.6.3 in Makefile`
+
+The **last item** should always be: `Update DEVTEMPLATE_VERSION to {VERSION} in Makefile`
+
+### 7. Summary
+
+After processing all repos, show a summary table:
+
+| Repo | Issue | Changes needed |
+|------|-------|----------------|
+| ... | #N (created/updated/skipped) | brief list |
+
+## Notes
+
+- This skill is read-only + issue creation. It does NOT modify repo code.
+- Skip repos where `DEVTEMPLATE_VERSION` already matches the current devtemplate version.
+- If unsure whether a difference is intentional, include it in the issue with a note to review.
+- Run from any directory — uses absolute paths.

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -1,0 +1,45 @@
+Ship a fix or feature end-to-end: issue, branch, commit, version bump, PR, squash merge, and cleanup.
+
+## Instructions
+
+Run this workflow in the current repo working directory. Adapt to whatever state the work is in — if changes are already committed, skip to the next step. If there's already a branch, use it.
+
+### 1. Issue
+- If the user described the work, create a GitHub issue with `gh issue create`
+- If an issue number was provided, use that
+- Note the issue number for the branch name
+
+### 2. Branch
+- Create and checkout a branch named `<issue-number>-<short-description>` from main
+- If already on a feature branch, use it
+
+### 3. Commit
+- Stage and commit changes with a conventional commit message (e.g. `fix:`, `feat:`, `chore:`)
+- Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+
+### 4. Version bump
+- Run `make bump-patch` to increment the patch version
+- The bump-patch target auto-commits (may include `[CC]` prefix from the make target — that's fine)
+
+### 5. Push and PR
+- Push the branch with `git push -u origin <branch>`
+- Create a PR with `gh pr create` linking the issue (`Closes #<number>`)
+- Use a clear, concise PR title (no `[CC]` prefix)
+
+### 6. Squash merge
+- Merge with `gh pr merge --squash --delete-branch`
+- This deletes the remote branch automatically
+
+### 7. Cleanup
+- Switch to main: `git checkout main`
+- Pull: `git pull`
+- Delete local branch: `git branch -d <branch>`
+- Prune: `git remote prune origin`
+
+### 8. Confirm
+- Run `git log --oneline -3` and `git branch -a` to show final state
+
+## Notes
+- Ask the user before proceeding if anything is ambiguous (e.g. patch vs minor bump)
+- If any step fails, diagnose and fix rather than skipping
+- The user may invoke this at any stage — detect where things are and pick up from there

--- a/skills/update-common/SKILL.md
+++ b/skills/update-common/SKILL.md
@@ -1,0 +1,75 @@
+Update the `common` submodule to latest and bump patch version across all repos in /workspaces.
+
+## Instructions
+
+This skill operates across multiple repos. Run it from /workspaces (not inside a single repo).
+
+### 1. Identify repos
+
+Find all git repos under /workspaces that have a `common` submodule:
+
+```bash
+for dir in /workspaces/*/; do
+  if [ -f "$dir/.gitmodules" ] && grep -q 'common' "$dir/.gitmodules"; then
+    echo "$dir"
+  fi
+done
+```
+
+### 2. For each repo, do the following
+
+Run these steps sequentially in each repo. Complete one repo before moving to the next.
+
+#### a. Ensure clean state
+
+- `git checkout main && git pull`
+- Confirm working tree is clean (`git status --porcelain` should be empty)
+- If not clean, stop and ask the user
+
+#### b. Create a branch
+
+- Branch name: `update-common`
+- `git checkout -b update-common`
+
+#### c. Update the common submodule
+
+```bash
+git submodule update --remote common
+git add common
+```
+
+- If there are no changes (submodule already at latest), skip this repo and clean up the branch
+- If there are changes, commit: `chore: update common submodule`
+
+#### d. Bump patch version
+
+- Run `make bump-patch`
+
+#### e. Push and create PR
+
+- `git push -u origin update-common`
+- Create PR with `gh pr create --title "chore: update common submodule" --body "Updates common submodule to latest and bumps patch version."`
+
+#### f. Squash merge
+
+- `gh pr merge --squash --delete-branch`
+
+#### g. Cleanup
+
+- `git checkout main && git pull`
+- `git branch -d update-common 2>/dev/null`
+- `git remote prune origin`
+
+### 3. Confirm
+
+After all repos are done, show a summary:
+
+- Which repos were updated (with new version)
+- Which repos were skipped (already up to date)
+- Run `git log --oneline -3` in each updated repo
+
+## Notes
+
+- If a repo already has an `update-common` branch, delete it first and start fresh
+- If any step fails, diagnose and fix rather than skipping
+- Ask the user before proceeding if anything is ambiguous


### PR DESCRIPTION
Closes #67.

Phase A of separating dev-common (generic, shared across stacks) from stack-common (home-site-specific).

## What changed
- **Genericize P1-P13** in `CLAUDE.md` to vocabulary only; each pattern points to `stack-common` for its concrete instance. Strips home-site names (panoptikon/oleo/minerva/twix/entities) that were leaking into non-home-site dev-common consumers (fra-site, standalone repos).
- **P14 (new):** documents the shared Claude Code skills mechanism.
- **Version-control the skills:** `incorporate-devtemplate`, `ship`, `update-common` moved into `skills/<name>/SKILL.md` (were untracked in `~/.claude/skills/`, lost on rebuild).
- **`setup-claude.sh`** symlinks `skills/*` into `~/.claude/skills/` (survives rebuilds; available in every repo session).
- **`make incorporate-devtemplate`** signpost target -> points at the skill (work needs judgment; no full automation).

## Verification
- `bash -n setup-claude.sh` OK; ran the symlink loop (links resolve).
- `make incorporate-devtemplate` prints the signpost; `make help` lists it; `make version-check` OK (0.10.3).

## Follow-ups (separate PRs)
- home-site-common gets a `CLAUDE.md` with the concrete instances.
- 8 stack repos add `@stack-common/CLAUDE.md`; brief + devtemplate pick up the genericized catalog via common-update.