### PR TITLE
fix: install shared skills as project-level relative symlinks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,9 +226,15 @@ Source for the wrappers + install docs lives in the stack's primary repo at
 
 ### P14: Shared Claude Code skills
 Reusable Claude Code skills live in `dev-common/skills/<name>/SKILL.md`
-(version-controlled, one source of truth). `setup-claude.sh` symlinks each
-into `~/.claude/skills/` so they are available in every repo's Claude Code
-session and survive devcontainer rebuilds. Current skills: `ship` (end-to-end
+(version-controlled, one source of truth). `setup-claude.sh` exposes each as a
+**project-level** skill via a per-repo *relative* symlink
+(`<repo>/.claude/skills/<name>` -> `../../common/skills/<name>`), so they are
+available in every repo's Claude Code session, live-update through
+`update-common` (the submodule bump — no copy, no rebuild), and never collide
+across containers that share one host `~/.claude`. (They are deliberately NOT
+symlinked into `~/.claude/skills/`: that dir is bind-mounted from the host into
+every container, so workspace-absolute links there are last-writer-wins and
+dangle in all but the most-recently-set-up container.) Current skills: `ship` (end-to-end
 issue -> PR -> squash-merge -> cleanup), `update-common` (bump the dev-common
 submodule across repos), `incorporate-devtemplate` (diff repos against
 devtemplate, file issues). `make incorporate-devtemplate` is a signpost that

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.4
+VERSION=0.10.5
 
 # Include our own shared targets
 include make/version.mk

--- a/devcontainer/setup-claude.sh
+++ b/devcontainer/setup-claude.sh
@@ -37,21 +37,37 @@ else
   echo "    Claude Code CLI already installed"
 fi
 
-# Install shared Claude Code skills from dev-common/skills/ into ~/.claude/skills/
-# (P14). They are version-controlled here (one source of truth) and symlinked, so
-# a `make common-update` is immediately reflected in every repo's Claude Code
-# session and the skills survive devcontainer rebuilds. The symlink replaces any
-# stale real copy left over from when these lived only in ~/.claude/skills/.
-echo "==> Installing shared Claude Code skills..."
-SKILLS_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills"
+# Install shared Claude Code skills from dev-common/skills/ (P14). They are
+# version-controlled here (one source of truth) and exposed to Claude Code as
+# PROJECT-level skills via per-repo RELATIVE symlinks:
+#     <repo>/.claude/skills/<name> -> ../../common/skills/<name>
+# This is deliberate. We previously symlinked into ~/.claude/skills/ with the
+# skill's workspace-ABSOLUTE path, but ~/.claude is bind-mounted from the host
+# into every devcontainer, so those links were last-writer-wins: whichever
+# container ran setup most recently repointed the shared links at its own
+# workspace, dangling them in all others (skills silently vanished). A
+# relative, in-workspace link instead:
+#   - resolves regardless of the absolute workspace path, so it never collides
+#     across containers that share one host ~/.claude;
+#   - points at this repo's own common/skills, so `make update-common` (which
+#     bumps the dev-common submodule) live-updates the skills with no copy and
+#     no devcontainer rebuild.
+echo "==> Installing shared Claude Code skills (project-level)..."
+COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${COMMON_DIR}/.." && pwd)"
+SKILLS_SRC="${COMMON_DIR}/skills"
+PROJ_SKILLS="${REPO_ROOT}/.claude/skills"
 if [ -d "$SKILLS_SRC" ]; then
-  mkdir -p "${HOME}/.claude/skills"
+  mkdir -p "$PROJ_SKILLS"
   for d in "$SKILLS_SRC"/*/; do
     [ -d "$d" ] || continue
     name="$(basename "$d")"
-    rm -rf "${HOME}/.claude/skills/${name}"
-    ln -s "${SKILLS_SRC}/${name}" "${HOME}/.claude/skills/${name}"
-    echo "    linked skill: ${name}"
+    rm -rf "${PROJ_SKILLS}/${name}"
+    ln -s "../../common/skills/${name}" "${PROJ_SKILLS}/${name}"
+    echo "    linked project skill: ${name}"
+    # Retire the legacy host-level link (workspace-absolute, shared across
+    # containers) so it can't shadow the project-level skill or dangle.
+    [ -L "${HOME}/.claude/skills/${name}" ] && rm -f "${HOME}/.claude/skills/${name}"
   done
 else
   echo "    no skills/ dir at $SKILLS_SRC (skipping)"

--- a/devcontainer/setup-claude.sh
+++ b/devcontainer/setup-claude.sh
@@ -62,7 +62,7 @@ if [ -d "$SKILLS_SRC" ]; then
   for d in "$SKILLS_SRC"/*/; do
     [ -d "$d" ] || continue
     name="$(basename "$d")"
-    rm -rf "${PROJ_SKILLS}/${name}"
+    rm -rf "${PROJ_SKILLS:?}/${name}"
     ln -s "../../common/skills/${name}" "${PROJ_SKILLS}/${name}"
     echo "    linked project skill: ${name}"
     # Retire the legacy host-level link (workspace-absolute, shared across


### PR DESCRIPTION
Closes #76.

### Problem
`setup-claude.sh` symlinked skills into `~/.claude/skills/` using the skill's **workspace-absolute** path. But `~/.claude` is bind-mounted from the host into **every** devcontainer, so the links were last-writer-wins: whichever container ran setup most recently repointed the shared links at *its* workspace, dangling them everywhere else. Skills like `/ship` silently vanished in any container that wasn't the last one set up.

### Fix
Expose skills as **project-level** skills via per-repo **relative** symlinks:
```
<repo>/.claude/skills/<name> -> ../../common/skills/<name>
```
- Lives **inside the workspace** and is **relative**, so it resolves regardless of the absolute path and **never collides** across containers sharing one host `~/.claude`.
- Points at the repo's own `common/skills`, so **`update-common` live-updates the skills** (no copy, no rebuild) — same channel as everything else in dev-common.
- Retires the stale `~/.claude/skills` links on setup.
- P14 docs updated to match.

### Testing
- `shellcheck` clean (incl. SC2115 guard on the `rm`).
- Verified the relative-symlink resolution in a live container: `<repo>/.claude/skills/ship -> ../../common/skills/ship` resolves to a valid `SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)