### PR TITLE
docs: update bdh-org token row (ci-runner -> actions-runner; add brief, roy)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ that matches the repo's GitHub org. Tokens live at
 
 | Token file | GitHub org | Used by |
 | --- | --- | --- |
-| `gh-bdh-org.token` | `bdh-org` | home-site, dev-common, devtemplate, ci-runner |
+| `gh-bdh-org.token` | `bdh-org` | home-site, dev-common, devtemplate, actions-runner, brief, roy |
 | `gh-finzeug.token` | `finzeug` | hog, oleo, canary, heller, panoptikon, refdims, ratecraft |
 | `gh-finriskanalytics.token` | `finriskanalytics` | freddyb |
 


### PR DESCRIPTION
Closes #78

Renames ci-runner -> actions-runner and adds brief, roy to the bdh-org row of the GitHub Authentication table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)