### PR TITLE
ci: repoint shared self-hosted workflows alfie -> forge

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(make bump-minor:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr:*)",
+      "Bash(git checkout:*)",
+      "Bash(gh run:*)",
+      "Bash(gh workflow:*)",
+      "Bash(git add:*)",
+      "Bash(git fetch:*)",
+      "Bash(gh issue:*)",
+      "Bash(git:*)",
+      "Bash(make:*)"
+    ]
+  }
+}

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   ci:
-    runs-on: [self-hosted, alfie]
+    runs-on: [self-hosted, forge]
     env:
       CONDA_ROOT: /home/github-runner/miniforge3
       CI_ENV: ${{ inputs.conda-env-name }}

--- a/.github/workflows/tag-version-self-hosted.yml
+++ b/.github/workflows/tag-version-self-hosted.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   tag:
-    runs-on: [self-hosted, alfie]
+    runs-on: [self-hosted, forge]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Retire alfie (home-infra issue 23). Repoints self-hosted-ci.yml + tag-version-self-hosted.yml to the forge label. AFFECTS ALL CONSUMERS across orgs — bdh-org + finzeug have forge runners, but **freddyb (finriskanalytics) uses these and finriskanalytics has NO forge runner yet**. Register a finriskanalytics forge runner before merging, or freddyb CI queues.