### PR TITLE
feat(devcontainer): fetch.prune + git gone alias (container + host)

### DIFF
--- a/devcontainer/init-host.sh
+++ b/devcontainer/init-host.sh
@@ -10,6 +10,13 @@ mkdir -p "${HOME}/.claude" "${HOME}/.config/ai/claude/identity/gh" "${HOME}/.con
 # Save host hostname for the container to use
 hostname > "$(dirname "$0")/.hostname"
 
+# Git hygiene on the HOST (idempotent), mirroring the container config: keep merged+
+# deleted branches from lingering locally. Guarded so a git hiccup can't abort init.
+if command -v git >/dev/null 2>&1; then
+  git config --global fetch.prune true
+  git config --global alias.gone '!git fetch -p && git branch -vv | awk "/: gone]/{print \$1}" | xargs -r git branch -D'
+fi
+
 # Ensure bind-mount source dirs exist (Docker fails if a mount source is
 # missing). Note: ~/.claude.json is intentionally NOT created/mounted anymore
 # — each container seeds its own copy in setup-claude.sh.

--- a/devcontainer/setup-base.sh
+++ b/devcontainer/setup-base.sh
@@ -88,4 +88,10 @@ alias ll='ls -alFT'
 EOF
 fi
 
+# Git hygiene (idempotent): auto-prune deleted remote branches on fetch/pull, and a
+# `git gone` alias to drop local branches whose upstream was merged+deleted -- keeps
+# checkouts from piling up stale branches after PRs merge on GitHub.
+git config --global fetch.prune true
+git config --global alias.gone '!git fetch -p && git branch -vv | awk "/: gone]/{print \$1}" | xargs -r git branch -D'
+
 echo "==> Base setup complete"


### PR DESCRIPTION
Closes #91. Adds `fetch.prune true` + a `git gone` alias to setup-base.sh (containers) and init-host.sh (host, guarded by `command -v git`) so merged+deleted branches stop lingering in local checkouts. Idempotent; propagates via update-common + rebuild. Left open for review.