### PR TITLE
feat(ci): shared svc-dev deploy+smoke gate (svcdev-gate.sh + smoke-dev.sh)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.6
+VERSION=0.10.7
 
 # Include our own shared targets
 include make/version.mk

--- a/ci/smoke-dev.sh
+++ b/ci/smoke-dev.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# smoke-dev.sh — HTTP smoke checks against a home-site svc-dev tier.
+#
+# SHARED, canonical copy (dev-common). Consumed by every stack repo's agent
+# workflow via the common/ submodule as `common/ci/smoke-dev.sh`, so the smoke
+# definition lives in ONE place and updates propagate through `update-common`.
+#
+# Default target is the svc-dev TEST TIER on twix: one Apache edge on :8080 with
+# per-service vhosts selected by the Host header (svc-dev is rootless and can't
+# bind :80, see home-infra#42). Run by svcdev-gate.sh after `claude-dev deploy
+# <ref> [<svc>]`: exit 0 = green. It verifies each service answers a sane HTTP
+# response through the edge; deliberately NOT exhaustive ("smoke").
+#
+# Usage:
+#   common/ci/smoke-dev.sh                    # svc-dev tier (twix:8080, Host <svc>.twix)
+#   common/ci/smoke-dev.sh --target min:80    # another edge (host:port)
+#   common/ci/smoke-dev.sh --base minerva     # vhost domain suffix (e.g. prod aliases)
+
+set -euo pipefail
+
+TARGET="twix:8080"   # host:port the edge Apache listens on
+BASE_SUFFIX="twix"   # vhost domain suffix -> requests carry Host: <svc>.<suffix>
+
+# Readiness: the gate smokes right after `compose up`, when Python backends may
+# still be booting (a 503 through the edge = upstream not listening YET, not broken).
+# Retry each check until it passes or SMOKE_RETRY_SECS elapses. Services boot in
+# parallel, so total time is ~the slowest single service, not the sum. A healthy
+# stack passes immediately (no wait). SMOKE_RETRY_SECS=0 => old one-shot behaviour.
+SMOKE_RETRY_SECS="${SMOKE_RETRY_SECS:-60}"
+SMOKE_RETRY_INTERVAL="${SMOKE_RETRY_INTERVAL:-2}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --target) TARGET="$2"; shift 2 ;;
+    --base)   BASE_SUFFIX="$2"; shift 2 ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+PASS=0
+FAIL=0
+
+# check <name> <vhost-host> <path> [expect_code]
+# Connects to $TARGET (the edge) and sets Host: <vhost-host> so Apache selects the
+# right vhost — the whole tier is one edge, routed by Host, not by port-per-service.
+check() {
+  local name="$1" vhost="$2" path="$3" expect_code="${4:-200}"
+  local code deadline
+  deadline=$(( $(date +%s) + SMOKE_RETRY_SECS ))
+  # Poll until the service answers as expected or the readiness budget elapses. A
+  # healthy stack matches on the first try; a just-started one gets time to boot.
+  while :; do
+    code=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 \
+             -H "Host: ${vhost}" "http://${TARGET}${path}" || echo "000")
+    [ "$code" = "$expect_code" ] && break
+    [ "$(date +%s)" -ge "$deadline" ] && break
+    sleep "$SMOKE_RETRY_INTERVAL"
+  done
+  if [ "$code" = "$expect_code" ]; then
+    printf "  PASS  %-24s Host:%-18s %s\n" "$name" "$vhost" "$path"
+    PASS=$((PASS+1))
+  else
+    printf "  FAIL  %-24s Host:%-18s %s -> %s (want %s, after %ss)\n" \
+      "$name" "$vhost" "$path" "$code" "$expect_code" "$SMOKE_RETRY_SECS"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+echo "=== target: ${TARGET}  (vhost suffix: .${BASE_SUFFIX}) ==="
+
+echo "--- edge (static site) ---"
+check "home-site root"    "${BASE_SUFFIX}"             "/"
+check "version.txt"       "${BASE_SUFFIX}"             "/version.txt"
+
+echo "--- services (through the edge vhosts) ---"
+check "panoptikon root"   "panoptikon.${BASE_SUFFIX}"  "/"
+check "freddyb health"    "freddyb.${BASE_SUFFIX}"     "/health"
+check "hog health"        "hog.${BASE_SUFFIX}"         "/api/v1/health"
+check "canary root"       "canary.${BASE_SUFFIX}"      "/"
+check "oleo root"         "oleo.${BASE_SUFFIX}"        "/"
+
+echo
+echo "=== summary: pass ${PASS}  fail ${FAIL} ==="
+[ "$FAIL" -eq 0 ]

--- a/ci/svcdev-gate.sh
+++ b/ci/svcdev-gate.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# svcdev-gate.sh — shared svc-dev deploy+smoke gate for the headless agent pipeline.
+#
+# SHARED, canonical copy (dev-common). Every stack repo's agent workflow calls this
+# via the common/ submodule, so the gate logic lives in ONE place (home-infra#42/#53)
+# and updates propagate through `update-common`:
+#
+#   common/ci/svcdev-gate.sh <service> <branch>
+#
+#   <service>  the repo's compose service (hog, oleo, ...). "" or "home-site" =>
+#              whole-stack deploy with no per-service checkout move (home-site's own
+#              workflow). Any other value is passed to `claude-dev deploy <ref> <svc>`,
+#              which moves THAT service's svc-dev checkout to the branch and rebuilds
+#              the tier -- so a service-repo PR is what gets built + smoked.
+#   <branch>   the PR branch to test (e.g. agent/issue-42).
+#
+# What it does (mirrors home-site's original inline gate): resolve the PR head SHA,
+# set a `svc-dev gate (deploy+smoke)` commit status = pending, SSH the claude-dev
+# deploy verb to twix, run smoke-dev.sh (its sibling), then set the status
+# success/failure and -- on failure -- comment the smoke tail ON the PR. Exits
+# non-zero on a red gate so the job (and any auto-merge step) fails.
+#
+# Env:
+#   GH_TOKEN        github.token -- for the commit status + PR comment (needs
+#                   contents:read, statuses:write, pull-requests:write).
+#   KEY_B64         base64 of the claude-dev SSH private key (a prior workflow step
+#                   fetches it from Vault kv/ai/coder/claude-dev-ssh).
+#   CLAUDE_DEV_SSH  ssh target for the forced-command verb (default claude@twix).
+#   GITHUB_REPOSITORY / GITHUB_SERVER_URL / GITHUB_RUN_ID  provided by Actions.
+#
+# Runs on the forge runner inside the agent workflow, AFTER claude-code-action has
+# opened the PR (so the verdict lands on it). bash -n clean; no secrets in argv.
+set -uo pipefail   # NOT -e: capture the gate result, then report it before exiting
+
+SVC="${1:-}"
+BRANCH="${2:?usage: svcdev-gate.sh <service> <branch>}"
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY unset (run inside GitHub Actions)}"
+TARGET="${CLAUDE_DEV_SSH:-claude@twix}"
+RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${REPO}/actions/runs/${GITHUB_RUN_ID:-}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+KEY="$(mktemp)"; LOG="$(mktemp)"; trap 'rm -f "$KEY" "$LOG"' EXIT
+printf '%s' "${KEY_B64:?KEY_B64 unset (fetch the claude-dev key from Vault first)}" | base64 -d > "$KEY"
+chmod 600 "$KEY"
+
+# PR head SHA = tip of the agent's branch (the job checked out the default branch).
+SHA="$(gh api "repos/${REPO}/commits/${BRANCH}" -q .sha 2>/dev/null || true)"
+set_status() {  # <state> <description>
+  [ -n "${SHA:-}" ] || return 0
+  gh api -X POST "repos/${REPO}/statuses/${SHA}" \
+    -f state="$1" -f context="svc-dev gate (deploy+smoke)" \
+    -f description="$2" -f target_url="${RUN_URL}" >/dev/null || true
+}
+
+# Service arg for the deploy verb: home-site (or empty) => whole-stack, no per-svc move.
+DEPLOY_SVC=""
+case "$SVC" in ""|home-site) ;; *) DEPLOY_SVC="$SVC" ;; esac
+
+set_status pending "deploying ${BRANCH}${DEPLOY_SVC:+ (${DEPLOY_SVC})} to svc-dev + smoke"
+echo "==> svc-dev gate: deploy ${BRANCH} ${DEPLOY_SVC:-<whole-stack>} via ${TARGET}, then smoke"
+if { ssh -i "$KEY" -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new \
+       "$TARGET" deploy "$BRANCH" $DEPLOY_SVC && "${HERE}/smoke-dev.sh"; } 2>&1 | tee "$LOG"; then
+  set_status success "svc-dev deploy + smoke passed"
+else
+  set_status failure "svc-dev deploy or smoke FAILED"
+  { echo "### svc-dev gate: FAILED"; echo
+    echo "Deploy-to-svc-dev + smoke did not pass. [Full run](${RUN_URL})."; echo
+    echo '```'; tail -n 30 "$LOG"; echo '```'
+  } | gh pr comment "$BRANCH" --body-file - || true
+  exit 1
+fi


### PR DESCRIPTION
Foundation for **finishing P2 across the stack** (home-infra#42/#53). Centralizes the svc-dev deploy+smoke gate in dev-common so every stack repo's agent workflow runs the *same* gate via the `common/` submodule, rather than a copy per repo.

## Adds
- `ci/svcdev-gate.sh <service> <branch>` — resolves the PR head, sets a `svc-dev gate (deploy+smoke)` commit status, SSHes `claude-dev deploy <branch> [<svc>]` to twix (moves that service's svc-dev checkout to the branch + rebuilds the tier), runs smoke, and records success/failure + a failure comment **on the PR**. `<service>=""`/`home-site` ⇒ whole-stack deploy (home-site's existing behaviour); any other compose service ⇒ per-service PR test.
- `ci/smoke-dev.sh` — the canonical smoke (readiness retry from home-site#277), reused by the gate.

## Rollout after this merges (separate PRs)
1. **home-site** — drop its local `scripts/smoke-dev.sh`, bump `common`, call `common/ci/svcdev-gate.sh home-site` (refactor to the shared gate).
2. **6 service repos** (freddyb, canary, panoptikon, hog, refdims, oleo) — bump `common`, add the gate step calling `common/ci/svcdev-gate.sh <repo>` to their agent workflow.
3. heller + dataflow get a DAG-parse gate (separate); brief/roy are stack-adjacent (separate).

Prereqs already confirmed: `provision-svcdev-bringup.sh` gives every service checkout a `github` remote + RO-App cred, and `claude-dev deploy <ref> <svc>` is allowlisted end-to-end.