### PR TITLE
chore: purge stale 'alfie' from reusable-workflow comments

### DIFF
--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -1,6 +1,6 @@
 name: Self-hosted CI
 
-# Reusable CI workflow that runs on the alfie self-hosted runner.
+# Reusable CI workflow that runs on the forge self-hosted runner.
 # Consumers add a thin wrapper:
 #
 #   jobs:
@@ -55,8 +55,8 @@ jobs:
         run: git submodule update --init common
 
       # Point CONDA_ROOT at the runner's REAL home rather than a hardcoded path:
-      # github-runner homes differently across CI hosts (alfie: /home/github-runner,
-      # forge: /srv/github-runner), and hardcoding forces a phantom dir. $HOME is the
+      # github-runner's home isn't the assumed /home/github-runner on forge (it's
+      # /srv/github-runner), and hardcoding forces a phantom dir. $HOME is the
       # runner user's home, so conda lives at <home>/miniforge3 -- portable across hosts.
       - name: Resolve CONDA_ROOT from the runner's home
         run: echo "CONDA_ROOT=$HOME/miniforge3" >> "$GITHUB_ENV"

--- a/.github/workflows/tag-version-self-hosted.yml
+++ b/.github/workflows/tag-version-self-hosted.yml
@@ -1,6 +1,6 @@
 name: Tag Version (self-hosted)
 
-# Reusable version-tagging workflow on the alfie self-hosted runner.
+# Reusable version-tagging workflow on the forge self-hosted runner.
 # Consumers add a thin wrapper:
 #
 #   on:
@@ -16,7 +16,7 @@ name: Tag Version (self-hosted)
 #
 # The tag still lands on github.com: the runner clones from and pushes to
 # github.com (authed by the injected GITHUB_TOKEN); only the executing machine
-# changes from a cloud runner to alfie.
+# changes from a cloud runner to forge.
 on:
   workflow_call:
 


### PR DESCRIPTION
Comment-only. `runs-on` was already `forge`; the comments still named the retired `alfie` runner. Fixing at the source so it propagates to the pinned submodule copies as repos bump `common`. Low blast radius.