### PR TITLE
docs: redefine P10 as runner-on-merge deploy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,12 +165,24 @@ Repos without a Python environment skip step 3:
 - P1 — orchestrator + Apache, no Python app code.
 - P2c — DB service, no Python env in the container.
 
-### P10: Production deployment with retry
-`prod-deploy-all` deploys the full stack from the primary repo via SSH.
-All git operations use `git_retry` (make define/call macro) — 5 attempts with
-10s backoff to handle transient DNS failures (Tailscale MagicDNS).
+### P10: Production deployment (runner-on-merge)
+Merging to main IS the production deploy. The repo's `ci-build` workflow
+(self-hosted runner) builds a SHA-tagged image, pushes it to the stack's
+registry, and triggers the deploy wrapper on the prod host
+(`ssh deploy@<host> "<svc> <sha>"`), which runs the stack's deploy script
+as the scoped prod service user: pull the image, restart the container,
+deliver the image-baked `dags/` (P7).
 
-`dev-deploy-all` is the parallel for the dev tier; see P12.
+`make prod-deploy` (stack deploy.mk) is a thin force-redeploy escape
+hatch — it re-triggers `ci-build` via `gh workflow run`, normally
+unnecessary. The primary repo's `prod-deploy-all` loops it over every
+service (fleet bring-up / DR); P2b static sites override `prod-deploy`
+to host-build and rsync their `dist/` instead of riding the runner.
+
+`dev-deploy-all` is the manually driven parallel for the dev tier; see
+P12. Its git operations use `git_retry` (make define/call macro) — 5
+attempts with 10s backoff to handle transient DNS failures (Tailscale
+MagicDNS).
 
 ### P11: Project scaffolding (devtemplate)
 New repos are created by cloning `devtemplate`, which embeds the standard

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.9
+VERSION=0.10.10
 
 # Include our own shared targets
 include make/version.mk

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.11
+VERSION=0.10.12
 
 # Include our own shared targets
 include make/version.mk


### PR DESCRIPTION
Closes #101. Closes bdh-org/home-infra#16.

P10 still described production deploy as prod-deploy-all building on the host over SSH. Since the runner cutover that is wrong: merge to main IS the deploy (ci-build on the self-hosted runner -> SHA-tagged registry image -> deploy wrapper on the prod host -> scoped service user pulls + restarts + delivers image-baked dags/). Rewritten to say so, with make prod-deploy / prod-deploy-all correctly framed as force-redeploy escape hatches (home-stack-common 1.1.18 shape) and the P2b dist/ rsync override noted. dev-deploy-all / git_retry paragraph kept, since the dev tier is still manually deployed.

This was the last remaining scope of home-infra#16 in this repo; sibling wording touch-ups in home-stack-common and home-site claude-access/INSTALL.md ride separate PRs (Refs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)