### PR TITLE
feat(ci): make --max-turns a caller input on agent reusables

### DIFF
--- a/.github/workflows/agent-issue-to-pr.yml
+++ b/.github/workflows/agent-issue-to-pr.yml
@@ -24,6 +24,16 @@ on:
         type: string
         required: false
         default: ""
+      max_turns:
+        description: >
+          Claude Code --max-turns budget for the agent run. The default caps cost on
+          small issues (~50 turns is plenty for a docs fix or config change); repos
+          whose agent issues are feature-scale (new adapters, cross-cutting refactors)
+          opt up in their thin wrapper -- 4 of 6 hog runs died at 50 on 2026-07-17
+          (finzeug/hog#335).
+        type: number
+        required: false
+        default: 50
 
 jobs:
   agent:
@@ -119,7 +129,7 @@ jobs:
               explains what is still red (include the gate's final output).
           claude_args: |
             --model claude-opus-4-8
-            --max-turns 50
+            --max-turns ${{ inputs.max_turns }}
             --allowedTools "Read,Write,Edit,Bash"
 
       # Authoritative dev-tier gate (post-step) -- re-runs the SAME gate as the final

--- a/.github/workflows/agent-pr-revise.yml
+++ b/.github/workflows/agent-pr-revise.yml
@@ -26,6 +26,14 @@ on:
         type: string
         required: false
         default: ""
+      max_turns:
+        description: >
+          Claude Code --max-turns budget for the revision run. Default matches
+          agent-issue-to-pr; revisions are usually smaller than the original
+          implementation, so most wrappers should leave this alone.
+        type: number
+        required: false
+        default: 50
 
 jobs:
   revise:
@@ -143,7 +151,7 @@ jobs:
             (`${{ steps.pr.outputs.ref }}`), which updates the existing PR.
           claude_args: |
             --model claude-opus-4-8
-            --max-turns 50
+            --max-turns ${{ inputs.max_turns }}
             --allowedTools "Read,Write,Edit,Bash"
 
       # Authoritative dev-tier gate (post-step), only for repos with a gate command.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.9
+VERSION=0.10.10
 
 # Include our own shared targets
 include make/version.mk


### PR DESCRIPTION
Closes #103

Adds a `max_turns` input (`type: number`, `default: 50`) to both agent reusables — `agent-issue-to-pr.yml` and `agent-pr-revise.yml` — and passes it through to `claude_args`. The default preserves current behavior for every existing thin wrapper; repos whose agent issues are feature-scale opt up in their wrapper (hog first: 4 of 6 runs on 2026-07-17 died on `error_max_turns` at 50 — finzeug/hog#335 #350 #351 #352).

🤖 Generated with [Claude Code](https://claude.com/claude-code)