### PR TITLE
fix(ci): submodule sync before hydrate (stale runner URLs)

### DIFF
--- a/.github/workflows/agent-issue-to-pr.yml
+++ b/.github/workflows/agent-issue-to-pr.yml
@@ -68,6 +68,10 @@ jobs:
           for k in $(git config --local --name-only --get-regexp '^url\.' || true); do
             git config --local --unset-all "$k" || true
           done
+          # sync FIRST: the persistent runner workspace keeps submodule URLs in
+          # .git/modules/*/config, and `submodule init` never overwrites them --
+          # a URL fixed in .gitmodules would otherwise stay broken forever (#105).
+          git submodule sync --recursive || true
           git -c "url.https://x-access-token:${T}@github.com/bdh-org/.insteadOf=https://github.com/bdh-org/" \
             submodule update --init --recursive
 

--- a/.github/workflows/agent-pr-revise.yml
+++ b/.github/workflows/agent-pr-revise.yml
@@ -93,6 +93,10 @@ jobs:
           for k in $(git config --local --name-only --get-regexp '^url\.' || true); do
             git config --local --unset-all "$k" || true
           done
+          # sync FIRST: the persistent runner workspace keeps submodule URLs in
+          # .git/modules/*/config, and `submodule init` never overwrites them --
+          # a URL fixed in .gitmodules would otherwise stay broken forever (#105).
+          git submodule sync --recursive || true
           git -c "url.https://x-access-token:${T}@github.com/bdh-org/.insteadOf=https://github.com/bdh-org/" \
             submodule update --init --recursive
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.10
+VERSION=0.10.11
 
 # Include our own shared targets
 include make/version.mk


### PR DESCRIPTION
Closes #105

`git submodule sync --recursive` before `update --init --recursive` in both agent reusables — the persistent forge workspace pins submodule URLs in `.git/modules/*/config` and `init` never overwrites, so panoptikon kept cloning the retired brianholland URL even after its ratecraft pin was fixed (panoptikon#510).

🤖 Generated with [Claude Code](https://claude.com/claude-code)