### PR TITLE
fix: revise agent must post a completion comment

### DIFF
--- a/.github/workflows/agent-pr-revise.yml
+++ b/.github/workflows/agent-pr-revise.yml
@@ -157,6 +157,11 @@ jobs:
             repository's CLAUDE.md conventions. Do NOT open a new pull request -- one
             already exists; you are updating it. Do NOT merge.
 
+            Address EVERY part of the request. If a part is beyond what you can
+            do here (needs a human decision, credentials, a different repo),
+            still address it in your completion comment (below) -- never drop a
+            part silently.
+
             Run the repo's fast local checks and fix any failures FIRST: `make
             version-check` and `make lint` (ignore "No rule to make target" if a repo
             doesn't have one). For any version change ALWAYS use `make bump-patch` --
@@ -170,6 +175,20 @@ jobs:
 
             Finally COMMIT (conventional-commit style) and PUSH to the SAME branch
             (`${{ steps.pr.outputs.ref }}`), which updates the existing PR.
+
+            REQUIRED last step -- post ONE completion comment on the PR
+            (`gh` may be absent; use curl with $GH_TOKEN:
+              curl -sS -X POST -H "Authorization: Bearer $GH_TOKEN" \
+                "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+                -d "$(python3 -c 'import json,sys;print(json.dumps({"body":sys.stdin.read()}))' <<'BODY'
+            ...your summary...
+            BODY
+            )" )
+            summarizing: (a) what you changed and pushed, (b) any part of the
+            request you did NOT complete and why, (c) the gate result if you ran
+            one. A run that ends without this comment is a FAILED revision even
+            if the code pushed -- the requester must never have to inspect
+            commits to learn what happened (dev-common#112).
           claude_args: |
             --model claude-opus-4-8
             --max-turns ${{ inputs.max_turns }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.13
+VERSION=0.10.14
 
 # Include our own shared targets
 include make/version.mk


### PR DESCRIPTION
Closes #112.

The first real any-PR /revise run ([brief#8](https://github.com/bdh-org/brief/pull/8)) did half its request (pushed the Vault-credential change, never touched the conflicts) and posted nothing after the auto-ack — the run ended green and the gap was only visible by inspecting mergeability and commits. (I finished that request by hand; this prevents the recurrence.)

Prompt changes in the reusable:
1. "Address EVERY part of the request" — parts beyond the agent's reach must be surfaced, never dropped silently.
2. A REQUIRED final PR comment: (a) what changed/pushed, (b) what was not completed and why, (c) gate result. Includes a curl fallback since `gh` is absent on some org runners. A run without this comment is defined as a failed revision even if code pushed.

Arms fleet-wide on merge (wrappers call `@main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)