### PR TITLE
ci: DAG delivery guardrail - dags/ must be baked into the image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,17 @@ jobs:
       - name: Version consistency
         run: make version-check
 
+      # Registry-image deploys deliver DAGs ONLY when the image bakes them: the
+      # merge-to-main pipeline ships the image, and Airflow tasks docker-run into
+      # it — a dags/ dir the Dockerfile never COPYs means merged DAG changes
+      # silently never land (bdh-org/home-infra#15; bit panoptikon/hog/freddyb).
+      - name: DAG delivery guardrail
+        run: |
+          if [ -d dags ] && [ -f Dockerfile ] && ! grep -Eq '^[[:space:]]*COPY[[:space:]]+.*dags' Dockerfile; then
+            echo "::error::dags/ exists but the Dockerfile never COPYs it — DAG changes will not be delivered by the registry image. Add 'COPY dags/ /app/dags/' (bdh-org/home-infra#15)."
+            exit 1
+          fi
+
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.14
+VERSION=0.10.15
 
 # Include our own shared targets
 include make/version.mk


### PR DESCRIPTION
Implements #114 (from bdh-org/home-infra#15). Adds one cheap step to the shared reusable CI: a repo with dags/ and a Dockerfile fails CI unless the Dockerfile COPYs dags - the silent-non-delivery failure mode that bit panoptikon/hog/freddyb rename changes.

Verified against all current consumers: hog, heller, freddyb, panoptikon, oleo all bake 'COPY dags/ /app/dags/' already, and the dag-less repos (canary, refdims, ferret) skip the check - so this lands green everywhere and only catches future regressions.

Note: bumps VERSION to 0.10.14, same number open PR #113 takes - whichever merges second needs a re-bump (happy to do it).

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)