### PR TITLE
fix(agent): dagparse registry cred from Vault (deploy-ci), not a GitHub secret

### DIFF
--- a/.github/workflows/agent-issue-to-pr.yml
+++ b/.github/workflows/agent-issue-to-pr.yml
@@ -115,15 +115,31 @@ jobs:
         run: /srv/github-runner/bin/vault-fetch-ci-secret.sh
 
       # dagparse gate: the gate docker-runs the shared plugin image, so log in to
-      # the registry BEFORE the agent -- the login persists in ~/.docker/config.json
-      # for the whole job, so the agent's self-gate can pull WITHOUT ever holding
-      # REGISTRY_RUNNER_PW (same shape as heller's old standalone; the secret rides
-      # in via the wrapper's `secrets: inherit`).
+      # the registry BEFORE the agent -- the login persists (run-scoped
+      # DOCKER_CONFIG, home-infra#154) for the whole job, so the agent's self-gate
+      # can pull WITHOUT ever holding the credential. The password comes from
+      # VAULT (kv/ci/deploy via deploy-ci -- the same source every ci-build.yml
+      # uses), NOT a GitHub secret: org secrets resolve EMPTY through a cross-org
+      # `secrets: inherit` reusable call (dev-common#118, caught by heller's
+      # first live validation run).
+      - name: Fetch registry credential from Vault (deploy-ci)
+        id: regpw
+        if: inputs.gate_cmd != '' && inputs.gate_kind == 'dagparse'
+        env:
+          VAULT_ADDR: ${{ vars.VAULT_ADDR }}
+          CODER_ROLE: deploy-ci
+          CODER_SECRET_PATH: kv/ci/deploy
+          CODER_SECRET_FIELD: registry_pw
+          SECRET_OUTPUT_NAME: registry_pw
+          SECRET_ENV_NAME: ""
+        run: /srv/github-runner/bin/vault-fetch-ci-secret.sh
+
       - name: Registry login (dagparse gate)
         if: inputs.gate_cmd != '' && inputs.gate_kind == 'dagparse'
         env:
           DOCKER_HOST: unix:///run/user/996/docker.sock
-        run: echo "${{ secrets.REGISTRY_RUNNER_PW }}" | docker login registry.home.arpa -u runner --password-stdin
+          DOCKER_CONFIG: /tmp/docker-config-${{ github.run_id }}
+        run: echo "${{ steps.regpw.outputs.registry_pw }}" | docker login registry.home.arpa -u runner --password-stdin
 
       - uses: anthropics/claude-code-action@v1
         env:
@@ -131,9 +147,11 @@ jobs:
           KEY_B64: ${{ steps.devkey.outputs.claude_dev_key_b64 }}
           GH_TOKEN: ${{ steps.coder.outputs.coder_token }}
           GATE_CMD: ${{ inputs.gate_cmd }}
-          # dagparse: the gate's docker calls need the forge rootless daemon; empty
-          # (svcdev/no-gate) is ignored by the docker CLI.
+          # dagparse: the gate's docker calls need the forge rootless daemon and the
+          # run-scoped config holding the registry login; empty (svcdev/no-gate) is
+          # ignored by the docker CLI.
           DOCKER_HOST: ${{ inputs.gate_kind == 'dagparse' && 'unix:///run/user/996/docker.sock' || '' }}
+          DOCKER_CONFIG: ${{ inputs.gate_kind == 'dagparse' && format('/tmp/docker-config-{0}', github.run_id) || '' }}
         with:
           claude_code_oauth_token: ${{ steps.vault.outputs.oauth_token }}
           github_token: ${{ steps.coder.outputs.coder_token }}
@@ -180,6 +198,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           KEY_B64: ${{ steps.devkey.outputs.claude_dev_key_b64 }}
           DOCKER_HOST: ${{ inputs.gate_kind == 'dagparse' && 'unix:///run/user/996/docker.sock' || '' }}
+          DOCKER_CONFIG: ${{ inputs.gate_kind == 'dagparse' && format('/tmp/docker-config-{0}', github.run_id) || '' }}
         run: ${{ inputs.gate_cmd }} "agent/issue-${{ github.event.issue.number }}"
 
       # agent-deploy trust tier: on a green gate, auto-merge (unless a protected path was

--- a/.github/workflows/agent-pr-revise.yml
+++ b/.github/workflows/agent-pr-revise.yml
@@ -149,14 +149,29 @@ jobs:
         run: /srv/github-runner/bin/vault-fetch-ci-secret.sh
 
       # dagparse gate: log in to the registry BEFORE the agent -- the login persists
-      # in ~/.docker/config.json for the whole job, so the agent's self-gate can pull
-      # the plugin image WITHOUT ever holding REGISTRY_RUNNER_PW (rides in via the
-      # wrapper's `secrets: inherit`).
+      # (run-scoped DOCKER_CONFIG, home-infra#154) for the whole job, so the agent's
+      # self-gate can pull the plugin image WITHOUT ever holding the credential.
+      # Password from VAULT (kv/ci/deploy via deploy-ci, same as ci-build), NOT a
+      # GitHub secret: org secrets resolve EMPTY through a cross-org
+      # `secrets: inherit` reusable call (dev-common#118).
+      - name: Fetch registry credential from Vault (deploy-ci)
+        id: regpw
+        if: steps.pr.outputs.skip != 'true' && inputs.gate_cmd != '' && inputs.gate_kind == 'dagparse'
+        env:
+          VAULT_ADDR: ${{ vars.VAULT_ADDR }}
+          CODER_ROLE: deploy-ci
+          CODER_SECRET_PATH: kv/ci/deploy
+          CODER_SECRET_FIELD: registry_pw
+          SECRET_OUTPUT_NAME: registry_pw
+          SECRET_ENV_NAME: ""
+        run: /srv/github-runner/bin/vault-fetch-ci-secret.sh
+
       - name: Registry login (dagparse gate)
         if: steps.pr.outputs.skip != 'true' && inputs.gate_cmd != '' && inputs.gate_kind == 'dagparse'
         env:
           DOCKER_HOST: unix:///run/user/996/docker.sock
-        run: echo "${{ secrets.REGISTRY_RUNNER_PW }}" | docker login registry.home.arpa -u runner --password-stdin
+          DOCKER_CONFIG: /tmp/docker-config-${{ github.run_id }}
+        run: echo "${{ steps.regpw.outputs.registry_pw }}" | docker login registry.home.arpa -u runner --password-stdin
 
       - uses: anthropics/claude-code-action@v1
         if: steps.pr.outputs.skip != 'true'
@@ -165,9 +180,11 @@ jobs:
           KEY_B64: ${{ steps.devkey.outputs.claude_dev_key_b64 }}
           GH_TOKEN: ${{ steps.coder.outputs.coder_token }}
           GATE_CMD: ${{ inputs.gate_cmd }}
-          # dagparse: the gate's docker calls need the forge rootless daemon; empty
-          # (svcdev/no-gate) is ignored by the docker CLI.
+          # dagparse: the gate's docker calls need the forge rootless daemon and the
+          # run-scoped config holding the registry login; empty (svcdev/no-gate) is
+          # ignored by the docker CLI.
           DOCKER_HOST: ${{ inputs.gate_kind == 'dagparse' && 'unix:///run/user/996/docker.sock' || '' }}
+          DOCKER_CONFIG: ${{ inputs.gate_kind == 'dagparse' && format('/tmp/docker-config-{0}', github.run_id) || '' }}
         with:
           claude_code_oauth_token: ${{ steps.vault.outputs.oauth_token }}
           github_token: ${{ steps.coder.outputs.coder_token }}
@@ -230,4 +247,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           KEY_B64: ${{ steps.devkey.outputs.claude_dev_key_b64 }}
           DOCKER_HOST: ${{ inputs.gate_kind == 'dagparse' && 'unix:///run/user/996/docker.sock' || '' }}
+          DOCKER_CONFIG: ${{ inputs.gate_kind == 'dagparse' && format('/tmp/docker-config-{0}', github.run_id) || '' }}
         run: ${{ inputs.gate_cmd }} "${{ steps.pr.outputs.ref }}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.16
+VERSION=0.10.17
 
 # Include our own shared targets
 include make/version.mk


### PR DESCRIPTION
Fixes the failure caught by heller's FIRST live dagparse validation run (finzeug/heller run 29846945375): 'echo "" | docker login ... password is empty' - secrets.REGISTRY_RUNNER_PW resolves EMPTY when the reusable is called cross-org with secrets:inherit (worked fine in heller's old in-repo standalone).

- Registry credential now fetched from Vault: kv/ci/deploy field registry_pw via the deploy-ci AppRole and vault-fetch-ci-secret.sh - the identical pattern every ci-build.yml uses, so the reusables now have zero GitHub-secret dependence.
- DOCKER_CONFIG run-scoped (/tmp/docker-config-<run_id>) on login + agent + gate steps (bdh-org/home-infra#154 hygiene; format() with github.run_id - the runner context is invalid outside steps, the lesson from #154's first pass).

Merging immediately (mechanical fix to today's #117 feature) and re-firing heller's validation run.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)