### PR TITLE
docs: freddyb moved to finzeug - retire the finriskanalytics token row

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,7 @@ that matches the repo's GitHub org. Tokens live at
 | Token file | GitHub org | Used by |
 | --- | --- | --- |
 | `gh-bdh-org.token` | `bdh-org` | home-site, dev-common, devtemplate, actions-runner, brief, roy |
-| `gh-finzeug.token` | `finzeug` | hog, oleo, canary, heller, panoptikon, refdims, ratecraft |
-| `gh-finriskanalytics.token` | `finriskanalytics` | freddyb |
+| `gh-finzeug.token` | `finzeug` | hog, oleo, canary, heller, panoptikon, refdims, ratecraft, ferret, freddyb |
 
 Pick the token from the repo's origin org
 (`git remote get-url origin`), then prefix the command:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.17
+VERSION=0.10.18
 
 # Include our own shared targets
 include make/version.mk


### PR DESCRIPTION
freddyb transferred to finzeug 2026-07-21 (bdh-org/home-infra#156): fold freddyb into the finzeug token row (adding ferret, which was missing from the table) and drop the finriskanalytics row - that org is now empty and its PAT is retiring. Mechanical docs change, merging directly per today's delegated pattern.

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)