### PR TITLE
feat: require a version bump on every PR that changes anything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,61 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: false
+          # The version-bump guard below diffs against the base branch, which
+          # needs more than the default shallow clone.
+          fetch-depth: 0
 
       - name: Clone dev-common submodule
         run: git submodule update --init common
 
       - name: Version consistency
         run: make version-check
+
+      # A merge to main must be identifiable by version (bdh-org/dev-common#124).
+      #
+      # `version-check` above tests INTERNAL consistency -- Makefile VERSION
+      # against __init__.py / package.json / VERSION_TXT. It has no notion of a
+      # base branch, so it passes happily on a PR that changed code and forgot
+      # to bump. finzeug/panoptikon#569 merged that way: VERSION stayed on a
+      # number #567 had already tagged, tag-version.yml (which triggers only on
+      # Makefile changes) never fired, and the deployed image reported someone
+      # else's version.
+      #
+      # Skips repos with no VERSION line, so this cannot break a repo that does
+      # not version this way. Allows a pure bump PR, which is the fix rather
+      # than a violation.
+      - name: Version bumped
+        if: github.event_name == 'pull_request'
+        run: |
+          set -eu
+          if ! grep -qE '^VERSION[[:space:]]*=' Makefile 2>/dev/null; then
+            echo "no VERSION in Makefile -- this repo does not version here, skipping"
+            exit 0
+          fi
+          base="origin/${{ github.base_ref }}"
+          git fetch --quiet origin "${{ github.base_ref }}"
+          head_v=$(grep -m1 -E '^VERSION[[:space:]]*=' Makefile | sed -E 's/^VERSION[[:space:]]*=[[:space:]]*//')
+          base_v=$(git show "$base:Makefile" 2>/dev/null | grep -m1 -E '^VERSION[[:space:]]*=' | sed -E 's/^VERSION[[:space:]]*=[[:space:]]*//' || echo "")
+          if [ -z "$base_v" ]; then
+            echo "no VERSION on $base -- nothing to compare, skipping"
+            exit 0
+          fi
+          if [ "$head_v" != "$base_v" ]; then
+            echo "version bumped: $base_v -> $head_v"
+            exit 0
+          fi
+          # Unchanged. Only a complaint if the PR changed something else.
+          changed=$(git diff --name-only "$base"...HEAD | grep -v '^Makefile$' || true)
+          if [ -z "$changed" ]; then
+            echo "nothing changed but the Makefile -- nothing to version"
+            exit 0
+          fi
+          echo "::error::VERSION is still $base_v but this PR changes:"
+          echo "$changed" | sed 's/^/  /'
+          echo "::error::Run 'make bump-patch' -- never edit the version by hand."
+          echo "::error::Without a bump, tag-version.yml does not fire and the"
+          echo "::error::deployed image reports a version belonging to another change."
+          exit 1
 
       # Registry-image deploys deliver DAGs ONLY when the image bakes them: the
       # merge-to-main pipeline ships the image, and Airflow tasks docker-run into

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -49,6 +49,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false      # nested cross-org submodules need explicit auth
+          # The version-bump guard below diffs against the base branch, which
+          # needs more than the default shallow clone.
+          fetch-depth: 0
           clean: true            # default: git reset --hard && git clean -ffdx
 
       - name: Fetch dev-common submodule
@@ -111,6 +114,47 @@ jobs:
 
       - name: Version consistency
         run: make version-check
+
+      # Same guard as the hosted workflow (bdh-org/dev-common#124). It has to be
+      # in BOTH: the incident that motivated it -- finzeug/panoptikon#569 merging
+      # on a version #567 had already tagged -- happened in a repo that uses THIS
+      # workflow, so putting the guard only in ci.yml would have missed its own
+      # motivating case.
+      #
+      # version-check above tests INTERNAL consistency (Makefile VERSION against
+      # __init__.py / package.json) and has no notion of a base branch, so it
+      # passes on a PR that changed code and forgot to bump.
+      - name: Version bumped
+        if: github.event_name == 'pull_request'
+        run: |
+          set -eu
+          if ! grep -qE '^VERSION[[:space:]]*=' Makefile 2>/dev/null; then
+            echo "no VERSION in Makefile -- this repo does not version here, skipping"
+            exit 0
+          fi
+          base="origin/${{ github.base_ref }}"
+          git fetch --quiet origin "${{ github.base_ref }}"
+          head_v=$(grep -m1 -E '^VERSION[[:space:]]*=' Makefile | sed -E 's/^VERSION[[:space:]]*=[[:space:]]*//')
+          base_v=$(git show "$base:Makefile" 2>/dev/null | grep -m1 -E '^VERSION[[:space:]]*=' | sed -E 's/^VERSION[[:space:]]*=[[:space:]]*//' || echo "")
+          if [ -z "$base_v" ]; then
+            echo "no VERSION on $base -- nothing to compare, skipping"
+            exit 0
+          fi
+          if [ "$head_v" != "$base_v" ]; then
+            echo "version bumped: $base_v -> $head_v"
+            exit 0
+          fi
+          changed=$(git diff --name-only "$base"...HEAD | grep -v '^Makefile$' || true)
+          if [ -z "$changed" ]; then
+            echo "nothing changed but the Makefile -- nothing to version"
+            exit 0
+          fi
+          echo "::error::VERSION is still $base_v but this PR changes:"
+          echo "$changed" | sed 's/^/  /'
+          echo "::error::Run 'make bump-patch' -- never edit the version by hand."
+          echo "::error::Without a bump, tag-version.yml does not fire and the"
+          echo "::error::deployed image reports a version belonging to another change."
+          exit 1
 
       - name: Lint
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.19
+VERSION=0.10.20
 
 # Include our own shared targets
 include make/version.mk

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.20
+VERSION=0.10.21
 
 # Include our own shared targets
 include make/version.mk


### PR DESCRIPTION
Closes [#124](https://github.com/bdh-org/dev-common/issues/124).

Brian: *"merge to main should include a version bump"*, across repos.

## What went wrong

[finzeug/panoptikon#569](https://github.com/finzeug/panoptikon/pull/569) merged touching only `forecast.py`. No
`make bump-patch`, so `VERSION` stayed at 2.12.24 — a number [#567](https://github.com/finzeug/panoptikon/pull/567) had already
tagged. `tag-version.yml` triggers on `push: main` filtered to
`paths: ['Makefile']`, so it never fired, no tag was cut, and the deployed
image reports a version belonging to a different change. **CI passed the whole
way.**

`make version-check` could not have caught it. It tests *internal consistency*
— Makefile `VERSION` against `__init__.py`, `package.json`, `VERSION_TXT` — and
all four agreed on 2.12.24, so OK was the correct answer. It has no notion of a
base branch.

## The guard

Compares `VERSION` on the head against `VERSION` on the base; fails when a PR
changes anything else without changing it. Deliberately narrow:

| | |
| --- | --- |
| `pull_request` only | a push to main has no base to compare against |
| skips repos with no `VERSION` line | cannot break a repo that does not version this way |
| skips PRs touching only the Makefile | a pure bump PR is the fix, not a violation |
| `fetch-depth: 0` | the default shallow clone cannot see the base |

The error names **`make bump-patch`** specifically, because the project rule is
that bumps go through the target and never a hand edit — an error saying
"bump the version" invites the hand edit that drifts `__init__.py`.

## Lands everywhere at once

Repos reference this as `bdh-org/dev-common/.github/workflows/ci.yml@main`, not
through the submodule pin, so there is no adoption round. It also applies to
this PR, which is why it carries its own bump.