### PR TITLE
docs: P13 puts claude-access in the infra repo, not the primary repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,8 +232,18 @@ vars `CLAUDE_PROD_HOST` / `CLAUDE_DEV_HOST` name. stack-common's
 `setup-stack-hosts.sh` writes those env vars at `/etc/profile.d` so they
 survive devcontainer rebuilds.
 
-Source for the wrappers + install docs lives in the stack's primary repo at
-`claude-access/`.
+Source for the wrappers + install docs lives in the stack's **infra/architect**
+repo at `claude-access/` — not the primary repo. These are host-provisioning
+scripts: they install to `/usr/local/bin` and `/etc` on the prod host as root,
+and a primary repo neither builds nor ships them, so carrying them there puts
+undeployed root-installed code inside a deployable service. The infra repo is
+also where the rest of the host provisioning lives, including the ACL grant for
+the reader these wrappers authenticate.
+
+One consequence to plan for: the infra repo is typically NOT synced to the prod
+host (being non-operational, it is not one of the deployed siblings), so the
+install cannot read from a checkout there. Deliver by push-rsync from the dev
+host instead — stage unprivileged, install as root, remove the staging dir.
 
 ### P14: Shared Claude Code skills
 Reusable Claude Code skills live in `dev-common/skills/<name>/SKILL.md`

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.21
+VERSION=0.10.22
 
 # Include our own shared targets
 include make/version.mk

--- a/devcontainer/setup-claude.sh
+++ b/devcontainer/setup-claude.sh
@@ -75,7 +75,7 @@ fi
 
 # Install the claude-prod shim that proxies to the prod wrapper over SSH.
 # The corresponding server-side scripts and one-time setup live in
-# brianholland/home-site:claude-access/.  The private key is expected at
+# bdh-org/home-infra:claude-access/.  The private key is expected at
 # ~/.config/ai/claude/credentials/prod-readonly (host bind-mounted into every
 # devcontainer per the bind mount in devtemplate's devcontainer.json).
 echo "==> Installing claude-prod shim..."
@@ -92,7 +92,7 @@ HOST="${CLAUDE_PROD_HOST:-prod}"
 
 if [[ ! -r "$KEY" ]]; then
   echo "claude-prod: missing key at $KEY" >&2
-  echo "claude-prod: run the one-time setup in home-site/claude-access/INSTALL.md" >&2
+  echo "claude-prod: run the one-time setup in home-infra/claude-access/INSTALL.md" >&2
   exit 2
 fi
 if [[ "$#" -eq 0 ]]; then
@@ -114,7 +114,7 @@ echo "    claude-prod shim installed at /usr/local/bin/claude-prod"
 # Install the claude-dev shim that proxies to the dev wrapper over SSH.
 # Parallel to claude-prod above; targets twix (the dev host) by default.
 # Server-side scripts and one-time setup live in
-# brianholland/home-site:claude-access/INSTALL-dev.md.
+# bdh-org/home-infra:claude-access/INSTALL-dev.md.
 echo "==> Installing claude-dev shim..."
 sudo tee /usr/local/bin/claude-dev >/dev/null <<'CLAUDE_DEV_EOF'
 #!/usr/bin/env bash
@@ -130,7 +130,7 @@ HOST="${CLAUDE_DEV_HOST:-twix}"
 
 if [[ ! -r "$KEY" ]]; then
   echo "claude-dev: missing key at $KEY" >&2
-  echo "claude-dev: run the one-time setup in home-site/claude-access/INSTALL-dev.md" >&2
+  echo "claude-dev: run the one-time setup in home-infra/claude-access/INSTALL-dev.md" >&2
   exit 2
 fi
 if [[ "$#" -eq 0 ]]; then


### PR DESCRIPTION
Closes #126

P13 said the wrappers live in the stack **primary** repo. It is a pattern definition, so that wording is what any future stack copies — and it is wrong. These install to `/usr/local/bin` and `/etc` on the prod host as root; a primary repo neither builds nor ships them, so carrying them there puts undeployed root-installed code inside a deployable service and splits the feature from the ACL grant that authorises the same reader.

Also records the consequence that is easy to miss: **the infra repo is typically not synced to the prod host**, so the install cannot read from a checkout there and must be push-rsynced from the dev host. In this stack that surfaced as `INSTALL.md` sourcing `/srv/svc-prod/stack-home-site/home-site/claude-access` — correct only while the files sat in a repo the deploy git-refreshes. A file move alone would have left an install that fails with `cannot stat` while looking clean in git.

Repoints `devcontainer/setup-claude.sh` too: four comments and two user-facing hint messages named `home-site/claude-access/INSTALL*.md`, which dangle once bdh-org/home-site#407 merges.

Moved for this stack in bdh-org/home-infra#194 (merged).