### PR TITLE
chore: move the headless agent pipeline to Opus 5

### DIFF
--- a/.github/workflows/agent-issue-to-pr.yml
+++ b/.github/workflows/agent-issue-to-pr.yml
@@ -185,7 +185,7 @@ jobs:
             - if it is STILL failing after 3 attempts, open a DRAFT pull request whose body
               explains what is still red (include the gate's final output).
           claude_args: |
-            --model claude-opus-4-8
+            --model claude-opus-5
             --max-turns ${{ inputs.max_turns }}
             --allowedTools "Read,Write,Edit,Bash"
 

--- a/.github/workflows/agent-pr-revise.yml
+++ b/.github/workflows/agent-pr-revise.yml
@@ -233,7 +233,7 @@ jobs:
             if the code pushed -- the requester must never have to inspect
             commits to learn what happened (dev-common#112).
           claude_args: |
-            --model claude-opus-4-8
+            --model claude-opus-5
             --max-turns ${{ inputs.max_turns }}
             --allowedTools "Read,Write,Edit,Bash"
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.22
+VERSION=0.10.23
 
 # Include our own shared targets
 include make/version.mk


### PR DESCRIPTION
Pins both reusable agent workflows to `claude-opus-5` instead of `claude-opus-4-8`:

- `.github/workflows/agent-issue-to-pr.yml` -- the `agent-pr` / `agent-deploy` label path
- `.github/workflows/agent-pr-revise.yml` -- the revision path

Every caller references these at `@main`, so this takes effect fleet-wide on merge with no per-repo bump.

Turn budget is untouched here (the `max_turns` input default stays 50). The five repos that override it to 150 in their wrappers -- heller, hog, refdims, ferret, panoptikon -- get separate one-line PRs.

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjPeAz2eAJDgv9A9iAB9Vb