### PR TITLE
feat: wire dev-common's own agent-pr pipeline

### DIFF
--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -1,0 +1,37 @@
+name: agent-issue-to-pr (wrapper)
+# Thin wrapper (home-infra#123; dev-common#132): owns the `issues: [labeled]`
+# trigger and the agent-pr label filter; the pipeline itself is the dev-common
+# reusable (one source of truth, same shape as tag-version + pr-revise).
+#
+# gate_cmd is empty: dev-common is not in the svc-dev tier, so there is no
+# deploy+smoke gate to run. An empty gate also disables agent-deploy auto-merge
+# in the reusable, which is why this repo carries only the agent-pr label --
+# the agent opens a PR and a human merges it (same posture as home-infra).
+#
+# FILENAME NOTE: every other repo calls its wrapper agent-issue-to-pr.yml, but
+# in dev-common that path IS the reusable, so the wrapper lives here as
+# issue-to-pr.yml -- exactly as the revise wrapper lives at pr-revise.yml.
+# Same behavior, different filename -- do not "fix" this.
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write        # push the agent's branch
+  pull-requests: write   # open the PR
+  issues: write          # comment status back on the issue
+  statuses: write        # gate commit status (unused here; harmless)
+  id-token: write        # claude-code-action mints a GitHub OIDC token
+
+concurrency:
+  group: agent-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  agent:
+    if: github.event.label.name == 'agent-pr' || github.event.label.name == 'agent-deploy'
+    uses: bdh-org/dev-common/.github/workflows/agent-issue-to-pr.yml@main
+    with:
+      # no deployable dev tier -> no gate, no agent-deploy auto-merge
+      gate_cmd: ""
+    secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.23
+VERSION=0.10.24
 
 # Include our own shared targets
 include make/version.mk


### PR DESCRIPTION
dev-common hosts the reusable `agent-issue-to-pr.yml` that the whole fleet calls, but had no wrapper of its own, so labelling a dev-common issue did nothing at all. This adds the missing half.

- `.github/workflows/issue-to-pr.yml` -- the `issues: [labeled]` trigger and label filter, calling the reusable at `@main`
- `gate_cmd: ""` -- dev-common is not in the svc-dev tier, so there is no deploy+smoke gate to run

The `agent-pr` label itself was created directly on the repo (label state is not a file), colour and description matched to home-infra.

An empty gate also disables `agent-deploy` auto-merge inside the reusable, which is why this repo carries only `agent-pr`: the agent opens a PR and a human merges it. That is the same posture as home-infra, the other PR-only repo.

**Filename:** the wrapper is `issue-to-pr.yml`, not `agent-issue-to-pr.yml`, because in this repo that path *is* the reusable implementation. It follows the existing local precedent -- the revise wrapper is `pr-revise.yml` for exactly the same reason. There is a comment in the file saying so, since it looks like an inconsistency until you know why.

**Note:** rebased onto main after [#130](https://github.com/bdh-org/dev-common/pull/130) merged, so the version lands cleanly on 0.10.24.

**Not testable until merged:** GitHub runs `issues`-triggered workflows from the default branch, so the `agent-pr` label does nothing until this is on main. First real test is labelling a dev-common issue afterwards.

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjPeAz2eAJDgv9A9iAB9Vb