### PR TITLE
feat: add the press-on skill for unattended work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.24
+VERSION=0.10.25
 
 # Include our own shared targets
 include make/version.mk

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.25
+VERSION=0.10.26
 
 # Include our own shared targets
 include make/version.mk

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.26
+VERSION=0.10.27
 
 # Include our own shared targets
 include make/version.mk

--- a/skills/press-on/SKILL.md
+++ b/skills/press-on/SKILL.md
@@ -2,7 +2,7 @@
 name: press-on
 description: Carry an agreed queue forward without stopping to ask. Decide open choices yourself, record each as a named parameter, and continue. Use when work must progress unattended.
 when_to_use: Fired on a loop for unattended work, or invoked directly to resume a queue that has stalled on a question rather than on a failure.
-argument-hint: [what to work on, and what done means]
+argument-hint: "[what to work on, and what done means]"
 disallowed-tools: AskUserQuestion
 ---
 

--- a/skills/press-on/SKILL.md
+++ b/skills/press-on/SKILL.md
@@ -2,6 +2,7 @@
 name: press-on
 description: Carry an agreed queue forward without stopping to ask. Decide open choices yourself, record each as a named parameter, and continue. Use when work must progress unattended.
 when_to_use: Fired on a loop for unattended work, or invoked directly to resume a queue that has stalled on a question rather than on a failure.
+argument-hint: [what to work on, and what done means]
 disallowed-tools: AskUserQuestion
 ---
 
@@ -18,7 +19,16 @@ composing a question, you have found a decision you are supposed to make.
 
 ## 1. Establish the queue
 
-Work out what is actually in flight before doing anything:
+**If you were given an argument, that argument is the queue.** It names the work and,
+usually, what finishing looks like. Take it literally: if it says take an issue to a
+merged PR, merging is authorised for that work; if it says open a PR, stop at the PR.
+Where it is silent on how far to go, default to a green PR and leave the merge.
+
+When a tick finds that stated work already complete, say so in one line and stop for
+this tick rather than inventing adjacent work. Starting unrequested initiatives
+unattended is its own failure.
+
+With no argument, work out what is actually in flight before doing anything:
 
 - the current branch and its uncommitted or unpushed work
 - open PRs you own, especially any that are red or have unaddressed review comments
@@ -115,8 +125,14 @@ Anything else means there is a next item, and you should be working on it.
 
 ## Notes on running this
 
-- Fired on a loop (`/loop 30m /press-on`), each tick re-injects these instructions at the
-  top of the turn, which is far more reliable than a rule read once at session start.
+- Fired on a loop (`/loop 20m /press-on <work>`), each tick re-injects these instructions
+  at the top of the turn, which is far more reliable than a rule read once at session
+  start. Loop ticks fire only when the session is idle, so a tick never interrupts work
+  in progress: it fires precisely when a turn has ended, which is the stall it exists to
+  catch. Read the interval as "the most time a single stall can cost".
+- State what done means in the argument. "Work issue #42" leaves the finish line to
+  interpretation; "take #42 to a merged PR with CI green" does not, and it is also how
+  merge authorisation is granted.
 - Do not pin this skill to a cheap model. It makes decisions that persist in the codebase.
   Control cost with the loop interval and, for headless runs, `--max-budget-usd` -- not by
   downgrading the model doing the thinking.

--- a/skills/press-on/SKILL.md
+++ b/skills/press-on/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: press-on
+description: Carry an agreed queue forward without stopping to ask. Decide open choices yourself, record each as a named parameter, and continue. Use when work must progress unattended.
+when_to_use: Fired on a loop for unattended work, or invoked directly to resume a queue that has stalled on a question rather than on a failure.
+disallowed-tools: AskUserQuestion
+---
+
+# Press on
+
+You are continuing work that must not stall while nobody is watching. The failure this
+exists to prevent is not a crash: it is ending a turn to ask a question that you could
+have answered yourself, so that hours pass with nothing done.
+
+`AskUserQuestion` is deliberately unavailable in this skill. That is not an oversight to
+work around. Do not simulate it by ending your turn with a question, by writing "let me
+know which you prefer", or by presenting options and stopping. If you find yourself
+composing a question, you have found a decision you are supposed to make.
+
+## 1. Establish the queue
+
+Work out what is actually in flight before doing anything:
+
+- the current branch and its uncommitted or unpushed work
+- open PRs you own, especially any that are red or have unaddressed review comments
+- issues assigned to the agent identity, and any queue stated in the conversation
+- the repo's own conventions (`CLAUDE.md`, `README.md`) if you have not already read them
+
+Pick the top item and work it to completion before starting another. Half-finishing three
+things is worse than finishing one.
+
+## 2. When an item is blocked, classify the block
+
+Every block is exactly one of three kinds. Classify it explicitly, because the response
+differs.
+
+**A decision you can make.** A threshold, a default, a name, a data-modelling choice, a
+library, a schema shape, an error-handling policy, an estimate. This is the common case
+and the whole reason this skill exists. Decide it. See section 3.
+
+**A fact only the user holds.** Something unknowable from the code, the data, or the
+docs: whether a real-world plan permits a rollover, what a vendor's contract says, which
+of two business meanings is intended. Do not guess these. See section 4.
+
+**An irreversible or outward-facing action.** Merging without authorisation, deleting
+data, force-pushing a shared branch, sending mail, posting publicly, rotating a
+credential, anything that touches production in a way that cannot be undone. Do not take
+these unattended. See section 4.
+
+Be honest in the classification, and be strict about the middle category. "I would rather
+the user chose" is not the same as "only the user can know". Most questions that feel
+like the second are the first.
+
+## 3. Decide it, and write the decision down
+
+When it is yours to decide:
+
+1. **Pick the most defensible value.** Prefer the one supported by the data in front of
+   you, then the one matching existing convention in the repo, then the conservative one.
+2. **Make it a named parameter, not a buried literal.** A constant with a name, a config
+   key, a function argument with a default, a documented environment variable. The point
+   is that changing it later is a one-line edit by someone who can find it.
+3. **Disclose it where the output is read.** A number that reaches a report, a dashboard
+   or a log should carry its assumption with it. A decision recorded only in a commit
+   message is invisible at the moment someone is trusting the number.
+4. **Say which kind it is.** A *parameter* is a decision: someone chose it, and it is
+   correct by definition. An *assumption* is an estimate standing in for something
+   unknown, and it deserves a sensitivity, a range, or at minimum a comment saying what
+   would change if it is wrong. Do not let an assumption masquerade as a parameter.
+5. **Record it in the trail.** See section 5.
+
+Then keep working. The decision is made; do not revisit it in the same run.
+
+## 4. When it genuinely is not yours
+
+Do not stop. Deferring an item is not the same as ending the turn.
+
+- File it as an issue in the right repo, with enough context to be answerable in one
+  reading: what is blocked, the specific question, the options you considered, and your
+  recommendation.
+- Assign it to the human, not the agent identity.
+- If a defensible interim value exists, take it, mark it clearly as provisional, and say
+  in the issue what would change when the real answer arrives. A stub that unblocks five
+  downstream tasks beats a clean stop.
+- **Then move to the next item in the queue.** One blocked item does not block the queue.
+
+## 5. Leave an auditable trail
+
+Someone will read this later, having missed everything that happened. In the PR body, the
+issue, or a decisions note, record for each choice: what was decided, what value, why
+that value, where it now lives, and how to change it. Keep it terse and factual.
+
+The test is whether the user can scan it in the morning, disagree with one line, and
+change that one thing without re-deriving the rest.
+
+## 6. Push your work
+
+Unpushed work is invisible and is lost if the session dies. Commit and push as you go,
+following the repo's branch and commit conventions. Open a PR rather than merging, unless
+merging was explicitly authorised for this work.
+
+## 7. Ending
+
+**A summary is not a stopping point.** Finishing a coherent unit and writing it up nicely
+is precisely the failure mode: each finished piece reads like a natural place to stop, and
+two or three items into a queue that is indistinguishable from stalling.
+
+End only when one of these is true, and state which one:
+
+1. the queue is empty;
+2. every remaining item is genuinely blocked on the human, and each one has been filed
+   and assigned;
+3. a failure blocks you that you cannot resolve, and you have said what you tried.
+
+Anything else means there is a next item, and you should be working on it.
+
+## Notes on running this
+
+- Fired on a loop (`/loop 30m /press-on`), each tick re-injects these instructions at the
+  top of the turn, which is far more reliable than a rule read once at session start.
+- Do not pin this skill to a cheap model. It makes decisions that persist in the codebase.
+  Control cost with the loop interval and, for headless runs, `--max-budget-usd` -- not by
+  downgrading the model doing the thinking.
+- A loop only fires while a session is alive, and a pending permission prompt is not a
+  turn boundary, so it will not be dismissed by a tick. For genuinely unattended runs,
+  pair this with a permission posture that cannot block (a complete allowlist, or a
+  bypass mode in an isolated container).


### PR DESCRIPTION
Adds `skills/press-on/SKILL.md`, stack-wide via the P14 symlink.

## What it is for

The recurring failure in unattended sessions is not a crash and not a permission prompt. It is being told to record a decision as a parameter and continue, and then ending the turn to ask anyway, so hours pass with almost nothing done.

The rule already exists -- home-infra's CLAUDE.md says a summary is not a stopping point, and the memory set says to pick, disclose and make configurable rather than hand the question back. It is still violated, because a rule read once at session start loses to the pull toward checking in. Firing this on a loop re-injects it at the top of every turn.

## The load-bearing part

`disallowed-tools: AskUserQuestion`. With the tool absent, the turn *cannot* stop to ask. That is what turns a guideline into a constraint; the prose alone would not.

It deliberately does **not** set `disable-model-invocation`. That field would make a `/loop` firing arrive as inert text rather than executing, which would silently no-op the whole thing.

## What it does

Establishes the queue, then for each blocked item classifies the block as one of three kinds: a decision it can make (decide it, name it as a parameter, disclose it where the output is read, distinguish parameter from assumption, continue); a fact only you hold; or an irreversible action. The latter two get filed and assigned to you, and it moves to the **next** item rather than stopping. It leaves an auditable trail so a decision can be overridden in the morning by changing one line.

## Model posture

Deliberately not pinned to a cheap model, unlike the watcher skill in [#128](https://github.com/bdh-org/dev-common/issues/128). This one makes decisions that persist in the codebase; cost belongs in the loop interval and `--max-budget-usd`, not in downgrading the model doing the thinking. That difference is why they are two skills.

## Using it

`/loop 30m /press-on`, ideally from a freshly cleared session. Reaching a repo needs a `common` submodule bump plus the P14 symlink; home-infra can have both as a follow-on once this merges.

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjPeAz2eAJDgv9A9iAB9Vb