### PR TITLE
fix: watch must not ask a question, it stalls the loop it serves

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.29
+VERSION=0.10.30
 
 # Include our own shared targets
 include make/version.mk

--- a/skills/watch/SKILL.md
+++ b/skills/watch/SKILL.md
@@ -2,6 +2,9 @@
 name: watch
 description: Cheap, exit-early polling for /loop ticks. Runs ONE probe against a named target — a repo's CI, a deploy, a PR's checks, the open-PR queue — and stops in a single line when nothing has changed; it only gathers detail when the probe went red or moved. Use for "is CI green?", "did the deploy land?", "any new PRs to review?". Not for fixing what it finds.
 model: haiku
+# A loop tick runs unattended: a question would end the turn and stall the loop
+# until a human returns, silently. Removing the tool makes that impossible.
+disallowed-tools: AskUserQuestion
 ---
 
 # watch — one probe per tick, then stop
@@ -45,7 +48,7 @@ command:
 | `<org>/<repo> deploy` | last `ci-build` run on `main` — merge to main *is* the deploy (P10), so its conclusion is whether the deploy landed |
 | `<org>/<repo> pr <n>` | `gh pr checks <n> --repo <org>/<repo>` |
 | `<org>/<repo> prs` | `gh pr list --repo <org>/<repo> --json number,title,updatedAt` |
-| anything else | ask once what single command answers it, then use only that |
+| anything else | derive the single probe from the target string. If it genuinely cannot be resolved, say so in one line and end the tick -- never ask |
 
 `gh` has no ambient auth here — pass the org-scoped token inline (see
 `CLAUDE.md`): `bdh-org` → `gh-bdh-org.token`, `finzeug` → `gh-finzeug.token`.


### PR DESCRIPTION
Raised in review on [#134](https://github.com/bdh-org/dev-common/pull/134), which merged before it was addressed.

The Targets table ended with `anything else | ask once what single command answers it`. For a skill whose entire purpose is being fired by `/loop`, asking is the one thing that cannot happen: a tick runs unattended, so a question ends the turn and the loop stalls until you come back. And it stalls **silently** -- the session is alive, nothing looks broken.

That also put `watch` in direct contradiction with its sibling `press-on` on the single point that matters most for unattended use.

Two changes:

- the fallback row now derives the probe from the target string, and if it genuinely cannot be resolved it says so in one line and ends the tick
- `disallowed-tools: AskUserQuestion` in the frontmatter, so the constraint is mechanical rather than a request the prose makes politely -- same enforcement `press-on` uses

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjPeAz2eAJDgv9A9iAB9Vb