### PR TITLE
fix: entrypoint-vault's no-op says WHICH Vault input is missing, and how

### DIFF
--- a/vault/entrypoint-vault.sh
+++ b/vault/entrypoint-vault.sh
@@ -62,8 +62,32 @@ set -euo pipefail
 log() { printf '[entrypoint-vault] %s\n' "$*" >&2; }
 
 # ---- Fallback: no Vault creds -> no-op passthrough (safe pre-cutover) --------
+# Say WHICH input is missing, and whether it is UNSET or EMPTY (home-infra#155).
+#
+# These are different failures with different fixes, and the old one-line message
+# collapsed all of them into the same sentence:
+#   UNSET  -> nothing in the compose chain mentions this var at all. The service's
+#             stub never mapped <SVC>_VAULT_* -> VAULT_* ("not mapped by the stub").
+#   EMPTY  -> compose interpolated a variable it knows about but has no value for.
+#             .env.vault was written without an entry for this service, i.e. it is
+#             not in vault-bootstrap's allowlist, or the bootstrapper token is
+#             absent so nothing was minted ("not minted" / "not injected").
+# The #141 post-mortem is exactly this: three look-alike failures, one message.
+# Lengths only, never values -- a length is diagnostic (a truncated secret-id shows
+# up as a wrong length) and reveals nothing.
+_state() {
+  eval "_isset=\${$1+x}; _val=\${$1:-}"
+  if [ -z "${_isset:-}" ]; then printf 'UNSET'
+  elif [ -z "$_val" ];  then printf 'EMPTY'
+  else printf 'set(%s chars)' "${#_val}"; fi
+}
 if [ -z "${VAULT_ROLE_ID:-}" ] || [ -z "${VAULT_SECRET_ID:-}" ]; then
-  log "VAULT_ROLE_ID/VAULT_SECRET_ID not set — skipping Vault fetch; using existing file/env fallbacks"
+  log "SKIPPING Vault fetch — using existing file/env fallbacks. Inputs:"
+  log "  VAULT_ADDR=$(_state VAULT_ADDR)  VAULT_ROLE_ID=$(_state VAULT_ROLE_ID)  VAULT_SECRET_ID=$(_state VAULT_SECRET_ID)"
+  log "  UNSET = this service's compose stub never mapped <SVC>_VAULT_* -> VAULT_*."
+  log "  EMPTY = the stub maps it, but .env.vault carried no value: the service is"
+  log "          missing from vault-bootstrap's VAULT_SERVICES allowlist, or the host"
+  log "          has no bootstrapper token so nothing was minted."
   exec "$@"
 fi
 


### PR DESCRIPTION
Closes #148. Part 3 of bdh-org/home-infra#155.

Behavior is unchanged — same condition, same fallback, same `exec "$@"`. Only the
log line changes, from one sentence covering three different failures to a
statement of which input was missing and what that implies.

### Before

```
[entrypoint-vault] VAULT_ROLE_ID/VAULT_SECRET_ID not set — skipping Vault fetch; using existing file/env fallbacks
```

...for all three of these, identically.

### After

**Stub never mapped `<SVC>_VAULT_*`:**

```
[entrypoint-vault] SKIPPING Vault fetch — using existing file/env fallbacks. Inputs:
[entrypoint-vault]   VAULT_ADDR=UNSET  VAULT_ROLE_ID=UNSET  VAULT_SECRET_ID=UNSET
```

**Stub is wired, but nothing was minted** (service missing from
vault-bootstrap's `VAULT_SERVICES`, or no bootstrapper token on the host):

```
[entrypoint-vault]   VAULT_ADDR=set(13 chars)  VAULT_ROLE_ID=EMPTY  VAULT_SECRET_ID=EMPTY
```

**Partially injected** — role-id arrived, secret-id did not:

```
[entrypoint-vault]   VAULT_ADDR=set(13 chars)  VAULT_ROLE_ID=set(9 chars)  VAULT_SECRET_ID=EMPTY
```

followed in each case by two lines saying what UNSET and EMPTY mean and where to
fix them.

Those are real runs of the shipped function against the three input states, not
mock-ups.

### Notes

**Lengths, never values.** A length is genuinely diagnostic — a truncated
secret-id presents as a wrong length — and reveals nothing. No value is ever
logged, and the existing "do NOT add `set -x`" rule still holds.

**UNSET vs EMPTY needs `${VAR+x}`,** not `${VAR:-}`: compose interpolating a
variable it has no value for yields an EMPTY string, while a stub that never
mentioned the variable leaves it UNSET. Collapsing those is what made the two
cases indistinguishable in the first place, so the check deliberately keeps them
apart.

### Reaching services

Log-only, and it reaches a service only when that service bumps `common` **and
rebuilds its image** — the script is `COPY`'d in at build time. Per-repo and
opt-in; nothing here needs a fan-out.

Companion (parts 1 and 2, host-side): bdh-org/home-infra#270.
