### PR TITLE
feat(identity): mark the seat container-locally, not per checkout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,35 @@ writes. These PATs authenticate as the `bdh-ai` service account; the
 ambient git identity (a personal token) must not be used for automated
 writes.
 
+## Saying which seat you are
+
+Every AI seat authenticates as the same `bdh-ai` account, so nothing GitHub
+records distinguishes them: an issue filed from any devcontainer reads
+`login: bdh-ai`, `type: User`, `performed_via_github_app: null`. Two
+mechanisms close that gap, one automatic and one yours to remember.
+
+**Commits and PRs — automatic, nothing to do.** `setup-claude-identity.sh`
+writes a container-local `~/.gitconfig-seat` setting `user.name` to
+`bdh-ai (architect)` or `bdh-ai (contractor/<repo>)`, derived from
+`PROJECT_NAME`. Only the display name varies; `user.email` stays `bdh-ai`
+for every seat.
+
+**Never set `user.name` or `user.email` in a repo's `.git/config`.** Repo
+checkouts are bind-mounted from the host, so a repo-local override is
+shared with the human's own session -- which is how two repos ended up
+attributing container commits to a person (bdh-org/home-infra#317). If a
+seat name looks wrong, fix `~/.gitconfig-seat`, never the repo.
+
+**Issues and issue comments — add a footer**, since these never touch git:
+
+```markdown
+<sub>filed from the <repo> devcontainer</sub>
+```
+
+Use the repo whose devcontainer you are running in, which is the directory
+your `CLAUDE.md` was loaded from -- not the repo the issue is filed against.
+They differ often: cross-repo work is normal from the architect workspace.
+
 ## Package Management
 - Install packages with `conda` (conda-forge) into the dev environment when possible.
 - Use `pip` only as a fallback when a package is not available on conda-forge.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.37
+VERSION=0.10.38
 
 # Include our own shared targets
 include make/version.mk

--- a/devcontainer/setup-claude-identity.sh
+++ b/devcontainer/setup-claude-identity.sh
@@ -48,6 +48,8 @@ if [ ! -f "$GITCONFIG" ]; then
 [credential "https://gist.github.com"]
 	helper =
 	helper = !/usr/bin/gh auth git-credential
+[include]
+	path = ~/.gitconfig-seat
 EOF
 fi
 
@@ -76,7 +78,49 @@ if [ -e "$HOME/.config/gh" ] && [ ! -L "$HOME/.config/gh" ]; then
 fi
 ln -sfn "$GH_DIR" "$HOME/.config/gh"
 
+# --- Per-seat commit attribution (bdh-org/home-infra#317) -------------------
+#
+# The "seat" is the devcontainer, so the marker has to be container-local, and
+# neither obvious place is:
+#
+#   * $GITCONFIG is bind-mounted from the host's ~/.config/ai/claude and is
+#     therefore SHARED BY EVERY CONTAINER -- a name written here labels all
+#     seats identically.
+#   * a repo's .git/config lives inside the checkout, and /workspaces/* are
+#     bind mounts of the host's working trees, so a local override is shared
+#     with the human's own session. This is not hypothetical: it is how
+#     hog and slingshot ended up committing as Brian personally.
+#
+# An include splits the difference -- the DIRECTIVE is shared and harmless
+# (git skips a missing include silently, so containers that have not run this
+# yet are unaffected), while the VALUE is a container-local file. Only
+# user.name is set; user.email stays bdh-ai for every seat, which is correct
+# because every seat IS bdh-ai. This is display-only, exactly as the
+# home-infra CLAUDE.md rule intended -- it just could not be done safely at
+# the layer that rule named.
+#
+# The bootstrap heredoc above only fires on a fresh host, so the directive is
+# also ensured idempotently here for hosts whose gitconfig already exists.
+if ! git config --file "$GITCONFIG" --get-all include.path 2>/dev/null \
+     | grep -qx '~/.gitconfig-seat'; then
+  git config --file "$GITCONFIG" --add include.path '~/.gitconfig-seat'
+fi
+
+# PROJECT_NAME is exported by each repo's .devcontainer/env.sh, derived from
+# the repo directory name -- so this needs no per-repo edit. home-infra is the
+# architect workspace (it bind-mounts the whole stack); everything else is a
+# contractor seat, named so "which devcontainer" is answerable, not just
+# "which role".
+case "${PROJECT_NAME:-unknown}" in
+  home-infra) SEAT="architect" ;;
+  unknown)    SEAT="unknown" ;;
+  *)          SEAT="contractor/$PROJECT_NAME" ;;
+esac
+printf '# Written by setup-claude-identity.sh -- container-local, do not commit.\n[user]\n\tname = bdh-ai (%s)\n' \
+  "$SEAT" > "$HOME/.gitconfig-seat"
+
 echo "==> ~/.gitconfig -> $GITCONFIG"
 echo "==> ~/.config/gh -> $GH_DIR"
+echo "==> seat -> $HOME/.gitconfig-seat"
 echo "    user.name = $(git config --get user.name)"
 echo "    user.email = $(git config --get user.email)"


### PR DESCRIPTION
Fixes the mechanism behind bdh-org/home-infra#317.

## The measurement

`git -C <repo> var GIT_AUTHOR_IDENT` across all 18 repos mounted in the architect devcontainer -- what git would actually stamp, not what a config file claims:

```
  home-infra   bdh-ai (architect) <...bdh-ai@users.noreply.github.com>   ok
  panoptikon   bdh-ai (architect) <...bdh-ai@users.noreply.github.com>   ok
  ledger-io    bdh-ai (architect) <...bdh-ai@users.noreply.github.com>   ok
  ratecraft    bdh-ai (architect) <...bdh-ai@users.noreply.github.com>   ok
  heller       bdh-ai             <...bdh-ai@users.noreply.github.com>   no marker
  canary       bdh-ai             <...bdh-ai@users.noreply.github.com>   no marker
  hog          bdh-ai             <brian.d.holland@...>                  LEAK
  slingshot    bdh-ai (architect) <brian.d.holland@...>                  LEAK
```

5 of 18 marked; two would attribute a container commit to Brian personally, slingshot while presenting as the architect seat.

## Why the rule could not have worked

Neither available config layer is per-seat:

- **`$GITCONFIG`** is bind-mounted from the host's `~/.config/ai/claude`, so it is **shared by every container** -- a seat name there labels all seats identically.
- **A repo's `.git/config`** lives in a checkout that is a bind mount of the host's working tree, so an override is **shared with Brian's own session**. This is how hog and slingshot got a personal address.

The `CLAUDE.md` rule named the second layer, which is the one that pollutes the host. 5-of-18 is the mechanism failing, not people forgetting.

## The fix

An include splits the two: the **directive** goes in the shared gitconfig (harmless -- git skips a missing include silently, so containers that have not run this stay unaffected), and the **value** is a container-local `~/.gitconfig-seat` written from `PROJECT_NAME`, which each repo's `.devcontainer/env.sh` already exports from the repo directory name. No per-repo edit, and one global setting covers all mounted repos instead of 18 hand edits.

`user.email` is untouched -- every seat *is* bdh-ai, so only the display name varies, exactly as the original rule intended.

The bootstrap heredoc only fires on a fresh host, so the include is **also ensured idempotently** on every run. Without that this change would be a no-op on the only host that matters.

## Verified, not asserted

| case | result |
| --- | --- |
| fresh host, `PROJECT_NAME=hog` | `bdh-ai (contractor/hog)`, email preserved |
| fresh host, `PROJECT_NAME=home-infra` | `bdh-ai (architect)`, email preserved |
| existing gitconfig with no include (the real host shape) | include added, seat resolves |
| three consecutive runs | exactly **1** include line |

Also adds a CLAUDE.md section covering both mechanisms and the issue-footer convention -- issues never touch git, and nothing GitHub records distinguishes the seats (`login: bdh-ai`, `type: User`, `performed_via_github_app: null`).

## Rollout note

This does **not** reach a repo until that repo bumps its `common` submodule and rebuilds. Current pins are far apart (hog and canary at 0.10.7, heller 0.10.19, panoptikon 0.10.37), so a rebuild alone changes nothing.