### PR TITLE
refactor(identity): say devcontainer/session/role, not "seat"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,24 +42,30 @@ writes. These PATs authenticate as the `bdh-ai` service account; the
 ambient git identity (a personal token) must not be used for automated
 writes.
 
-## Saying which seat you are
+## Saying which devcontainer you are
 
-Every AI seat authenticates as the same `bdh-ai` account, so nothing GitHub
+Vocabulary, because these get conflated: a **devcontainer** is the environment
+(one per repo); a **session** is one running Claude Code conversation inside
+one; a **role** is what that session acts as -- **architect** or
+**contractor**. The role follows the devcontainer, so naming the devcontainer
+names the role.
+
+Every session authenticates as the same `bdh-ai` account, so nothing GitHub
 records distinguishes them: an issue filed from any devcontainer reads
 `login: bdh-ai`, `type: User`, `performed_via_github_app: null`. Two
 mechanisms close that gap, one automatic and one yours to remember.
 
 **Commits and PRs — automatic, nothing to do.** `setup-claude-identity.sh`
-writes a container-local `~/.gitconfig-seat` setting `user.name` to
+writes a container-local `~/.gitconfig-role` setting `user.name` to
 `bdh-ai (architect)` or `bdh-ai (contractor/<repo>)`, derived from
 `PROJECT_NAME`. Only the display name varies; `user.email` stays `bdh-ai`
-for every seat.
+everywhere.
 
 **Never set `user.name` or `user.email` in a repo's `.git/config`.** Repo
 checkouts are bind-mounted from the host, so a repo-local override is
-shared with the human's own session -- which is how two repos ended up
+shared with the human's own shell -- which is how two repos ended up
 attributing container commits to a person (bdh-org/home-infra#317). If a
-seat name looks wrong, fix `~/.gitconfig-seat`, never the repo.
+role name looks wrong, fix `~/.gitconfig-role`, never the repo.
 
 **Issues and issue comments — add a footer**, since these never touch git:
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.38
+VERSION=0.10.39
 
 # Include our own shared targets
 include make/version.mk

--- a/devcontainer/setup-claude-identity.sh
+++ b/devcontainer/setup-claude-identity.sh
@@ -49,7 +49,7 @@ if [ ! -f "$GITCONFIG" ]; then
 	helper =
 	helper = !/usr/bin/gh auth git-credential
 [include]
-	path = ~/.gitconfig-seat
+	path = ~/.gitconfig-role
 EOF
 fi
 
@@ -78,49 +78,62 @@ if [ -e "$HOME/.config/gh" ] && [ ! -L "$HOME/.config/gh" ]; then
 fi
 ln -sfn "$GH_DIR" "$HOME/.config/gh"
 
-# --- Per-seat commit attribution (bdh-org/home-infra#317) -------------------
+# --- Per-devcontainer commit attribution (bdh-org/home-infra#317) -----------
 #
-# The "seat" is the devcontainer, so the marker has to be container-local, and
-# neither obvious place is:
+# Which ROLE a session is acting in -- architect or contractor -- is a property
+# of the devcontainer it runs in, so the marker has to be container-local. The
+# two obvious places both leak:
 #
 #   * $GITCONFIG is bind-mounted from the host's ~/.config/ai/claude and is
-#     therefore SHARED BY EVERY CONTAINER -- a name written here labels all
-#     seats identically.
+#     therefore SHARED BY EVERY DEVCONTAINER -- a name written here labels
+#     every session identically.
 #   * a repo's .git/config lives inside the checkout, and /workspaces/* are
 #     bind mounts of the host's working trees, so a local override is shared
-#     with the human's own session. This is not hypothetical: it is how
-#     hog and slingshot ended up committing as Brian personally.
+#     with the human's own shell. This is not hypothetical: it is how hog and
+#     slingshot ended up committing as Brian personally.
 #
 # An include splits the difference -- the DIRECTIVE is shared and harmless
-# (git skips a missing include silently, so containers that have not run this
-# yet are unaffected), while the VALUE is a container-local file. Only
-# user.name is set; user.email stays bdh-ai for every seat, which is correct
-# because every seat IS bdh-ai. This is display-only, exactly as the
-# home-infra CLAUDE.md rule intended -- it just could not be done safely at
-# the layer that rule named.
+# (git skips a missing include silently, so devcontainers that have not run
+# this yet are unaffected), while the VALUE is a container-local file. Only
+# user.name is set; user.email stays bdh-ai everywhere, which is correct
+# because every session IS bdh-ai. Display-only, exactly as the home-infra
+# CLAUDE.md rule intended -- it just could not be done safely at the layer
+# that rule named.
 #
 # The bootstrap heredoc above only fires on a fresh host, so the directive is
 # also ensured idempotently here for hosts whose gitconfig already exists.
+#
+# MIGRATION: this file was briefly called ~/.gitconfig-seat. "Seat" is a
+# GitHub billing term and meant nothing here, so it is now ~/.gitconfig-role,
+# naming what it actually holds. Drop the old include and the stale file, or
+# the shared gitconfig accumulates both and the dead one wins or loses by
+# ordering rather than by intent.
+if git config --file "$GITCONFIG" --get-all include.path 2>/dev/null \
+   | grep -qx '~/.gitconfig-seat'; then
+  git config --file "$GITCONFIG" --unset-all include.path '~/.gitconfig-seat'
+fi
+rm -f "$HOME/.gitconfig-seat"
+
 if ! git config --file "$GITCONFIG" --get-all include.path 2>/dev/null \
-     | grep -qx '~/.gitconfig-seat'; then
-  git config --file "$GITCONFIG" --add include.path '~/.gitconfig-seat'
+     | grep -qx '~/.gitconfig-role'; then
+  git config --file "$GITCONFIG" --add include.path '~/.gitconfig-role'
 fi
 
 # PROJECT_NAME is exported by each repo's .devcontainer/env.sh, derived from
 # the repo directory name -- so this needs no per-repo edit. home-infra is the
-# architect workspace (it bind-mounts the whole stack); everything else is a
-# contractor seat, named so "which devcontainer" is answerable, not just
-# "which role".
+# architect workspace (it bind-mounts the whole stack); every other
+# devcontainer is a contractor one, named so "which devcontainer" is
+# answerable and not merely "which role".
 case "${PROJECT_NAME:-unknown}" in
-  home-infra) SEAT="architect" ;;
-  unknown)    SEAT="unknown" ;;
-  *)          SEAT="contractor/$PROJECT_NAME" ;;
+  home-infra) ROLE="architect" ;;
+  unknown)    ROLE="unknown" ;;
+  *)          ROLE="contractor/$PROJECT_NAME" ;;
 esac
 printf '# Written by setup-claude-identity.sh -- container-local, do not commit.\n[user]\n\tname = bdh-ai (%s)\n' \
-  "$SEAT" > "$HOME/.gitconfig-seat"
+  "$ROLE" > "$HOME/.gitconfig-role"
 
 echo "==> ~/.gitconfig -> $GITCONFIG"
 echo "==> ~/.config/gh -> $GH_DIR"
-echo "==> seat -> $HOME/.gitconfig-seat"
+echo "==> role -> $HOME/.gitconfig-role"
 echo "    user.name = $(git config --get user.name)"
 echo "    user.email = $(git config --get user.email)"


### PR DESCRIPTION
"Seat" is a GitHub and SaaS billing term -- a paid licence slot. Nothing here is licensed per anything, and Brian's verdict was that it *"makes no sense here"*. He is right, and I made it worse: I inherited the word from home-infra's `CLAUDE.md` and then propagated it into this shared file and into a filename now deployed across all 16 repos.

It was also doing three jobs at once:

| what was meant | word now used |
| --- | --- |
| the environment | **devcontainer** |
| one running Claude Code conversation | **session** |
| architect vs contractor | **role** |

That vagueness cost something the same day it appeared. Reasoning about "spinning up a seat costs more than it buys" concealed that the devcontainer in question was **already running**, and produced a recommendation built on a cost that did not exist.

## The roles stay

Architect and contractor carry the relationship the building-trade metaphor was chosen for -- one draws, one builds to the drawing, and the drawer inspects the work. Only the noun for the container and the conversation changes.

## `~/.gitconfig-seat` -> `~/.gitconfig-role`

Renamed to say what it holds. The script **migrates** rather than just switching: it removes the old include from the shared gitconfig and deletes the stale file. Without that the shared config accumulates both entries and which one wins is decided by ordering rather than by intent -- and the shared gitconfig is bind-mounted, so every devcontainer would inherit the ambiguity.

## Verified, not asserted

| case | result |
| --- | --- |
| fresh host, `PROJECT_NAME=hog` | `bdh-ai (contractor/hog)`, one include |
| fresh host, `PROJECT_NAME=home-infra` | `bdh-ai (architect)`, one include |
| **existing host with the OLD include + a stale `~/.gitconfig-seat`** | old include removed, stale file deleted, new name resolves |
| three further runs | exactly one include, unchanged |

## Rollout

Needs a `common` bump across all 16 repos again, then a rebuild -- the same path #154 took this morning. I will run the bumps once this merges.

Companion prose fix for home-infra's own `CLAUDE.md` follows separately.