### PR TITLE
docs: hyperlink issue/PR refs, and say which they are

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,32 @@ Use a concise, descriptive title.
 
 Example: `feat: add user authentication`
 
+## Referring to issues and PRs
+
+**Every issue or PR number in text the user reads is a hyperlink, and says which
+it is.** Never a bare `#441`, and never a bare `hog#441`.
+
+```markdown
+PR [hog#441](https://github.com/finzeug/hog/pull/441)
+issue [slingshot#138](https://github.com/finzeug/slingshot/issues/138)
+```
+
+Two separate requirements, and both are needed:
+
+1. **A link.** Brian reads in a terminal, where markdown links are clickable. A
+   bare number costs him a manual lookup every single time.
+2. **The word "PR" or "issue" beside it.** Issues and PRs share one number
+   space, so `hog#441` cannot say which it is, and the rendered link text hides
+   the `/pull/` vs `/issues/` that would have told him. Grouping works too
+   ("PRs merged: ...", "Issues: ...").
+
+Org for the URL, from the repo's `origin`: `bdh-org` (home-infra, home-site,
+dev-common, devtemplate, brief, roy), `finzeug` (hog, oleo, canary, heller,
+panoptikon, refdims, ratecraft, ferret, freddyb, slingshot, ledger-io).
+
+This is here rather than in a memory note because it kept regressing when it was
+only a note. Brian has asked for it repeatedly.
+
 ## GitHub Authentication
 The devcontainer has **no ambient `gh` auth** — this is deliberate, not a
 misconfiguration. `GITHUB_TOKEN` is intentionally empty and `gh`'s

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.10.39
+VERSION=0.10.40
 
 # Include our own shared targets
 include make/version.mk


### PR DESCRIPTION
Brian, today: *"I've asked FOR WEEKS for these numbered things to be hyperlinks so I can click them and read them."*

Two requirements, and both are needed:

1. **A link** — he reads in a terminal, where markdown links are clickable. A bare number costs a manual lookup every time.
2. **The word "PR" or "issue" beside it** — the two share one number space, so `hog#441` cannot say which it is, and the rendered link text hides the `/pull/` vs `/issues/` that would have told him.

This already lived in a memory note that was detailed and correct, including a 2026-07-16 addition specifically about issue-vs-PR disambiguation. It kept regressing anyway — I wrote a bare `hog#441` in the same session I was citing the rule from.

**Memory is advisory; `CLAUDE.md` is loaded as project instructions.** That is the only thing this change alters, and it is the thing that was missing.

bdh-org/home-infra#329 did the same for the architect workspace; this is the fleet-wide half, so every session in every repo picks it up.